### PR TITLE
fix(ui): カードバッジ折り返し修正・モーダルサイズ調整・ラベル短縮

### DIFF
--- a/src/components/cardList/CardListItem.tsx
+++ b/src/components/cardList/CardListItem.tsx
@@ -85,7 +85,7 @@ export const CardListItem = memo(function CardListItem({
               {card.name}
             </h2>
           </div>
-          <div className="flex flex-wrap gap-1">
+          <div className="flex flex-nowrap gap-1 overflow-hidden">
             {/* レアリティバッジ（SSR / SR / R） */}
             <Badge size={BadgeSizeType.Sm} weight={BadgeWeightType.Black} color={rarityEntry.color}>
               {t(rarityEntry.label)}
@@ -119,9 +119,9 @@ export const CardListItem = memo(function CardListItem({
           </span>
           {/* アビリティバッジ */}
           {abilityBadges.length > 0 && (
-            <div className="ml-auto flex flex-nowrap gap-0.5 justify-end overflow-hidden min-w-0">
+            <div className="flex-1 flex flex-nowrap gap-0.5 overflow-x-auto scrollbar-none min-w-0" style={{ direction: 'rtl' }}>
               {abilityBadges.map((badge, i) => (
-                <span key={i} className={constant.BADGE_ABILITY_GRID}>{t(badge)}</span>
+                <span key={i} className={constant.BADGE_ABILITY_GRID} style={{ direction: 'ltr' }}>{t(badge)}</span>
               ))}
             </div>
           )}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -33,7 +33,7 @@ export function Badge({
   className = '',
 }: BadgeProps) {
   return (
-    <span className={`${getBadgeSizeStyle(size)} ${getBadgeWeightClass(weight)} ${color} ${className}`.trim()}>
+    <span className={`${getBadgeSizeStyle(size)} ${getBadgeWeightClass(weight)} ${color} shrink-0 whitespace-nowrap ${className}`.trim()}>
       {children}
     </span>
   )

--- a/src/constant/styles.ts
+++ b/src/constant/styles.ts
@@ -53,7 +53,7 @@ export const DROPDOWN_PANEL =
 
 /** アビリティバッジ（グリッドカード用） */
 export const BADGE_ABILITY_GRID =
-  'px-1 py-0.5 rounded-full text-[8px] font-bold bg-slate-100 text-slate-500 border border-slate-200 whitespace-nowrap'
+  'px-1 py-0.5 rounded-full text-[8px] font-bold bg-slate-100 text-slate-500 border border-slate-200 whitespace-nowrap shrink-0'
 
 /** フィルターグループ間の縦線 */
 export const FILTER_SEPARATOR = 'w-px h-5 bg-slate-200'
@@ -80,7 +80,7 @@ export const MODAL_BACKDROP = 'absolute inset-0 bg-black/40 backdrop-blur-sm'
 export const MODAL_PANEL_DETAIL = 'relative bg-white rounded-2xl shadow-2xl max-w-2xl w-full h-[90vh] overflow-y-auto'
 
 /** モーダル白パネル（スコア内訳用） */
-export const MODAL_PANEL_SCORE = 'relative bg-white rounded-2xl shadow-2xl max-w-md w-full h-[80vh] flex flex-col overflow-hidden'
+export const MODAL_PANEL_SCORE = 'relative bg-white rounded-2xl shadow-2xl max-w-md w-full max-h-[80vh] flex flex-col overflow-hidden'
 
 /** モーダル白パネル（フィルタ・ソート用） */
 export const MODAL_PANEL_FILTER = 'relative bg-white rounded-2xl shadow-2xl max-w-md w-full h-[85vh] flex flex-col overflow-hidden'

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -47,11 +47,11 @@
   },
   "card": {
     "source": {
-      "gacha": "ガシャ",
-      "coin_gacha": "コインガシャ",
-      "season_limited": "季節限定",
-      "unit_limited": "ユニット限定",
-      "live_tour_limited": "ライブツアー限定",
+      "gacha": "恒常",
+      "coin_gacha": "コイン",
+      "season_limited": "季節",
+      "unit_limited": "ユニット",
+      "live_tour_limited": "ライブツアー",
       "hatsuboshi_fes": "フェス",
       "event": "イベント",
       "initial": "初期",

--- a/src/index.css
+++ b/src/index.css
@@ -19,3 +19,11 @@ body {
 .animate-slide-in-right {
   animation: slide-in-right 0.25s ease-out;
 }
+
+.scrollbar-none {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-none::-webkit-scrollbar {
+  display: none;
+}


### PR DESCRIPTION
## 概要

カードリストのバッジ表示とモーダルサイズに関するUI不具合を修正する。

## 変更内容

### バッジ折り返し防止
- `CardListItem.tsx`: 上段バッジ行を `flex-wrap` → `flex-nowrap overflow-hidden` に変更
- `Badge.tsx`: `shrink-0 whitespace-nowrap` を追加し、バッジが縮小・折り返しされないように

### アビリティバッジ横スクロール
- `CardListItem.tsx`: バッジコンテナを `overflow-x-auto scrollbar-none` + `direction: rtl` で右寄せスクロール対応
- `styles.ts`: `BADGE_ABILITY_GRID` に `shrink-0` 追加
- `index.css`: `.scrollbar-none` クラス追加

### モーダルサイズ調整
- `styles.ts`: `MODAL_PANEL_SCORE` を `h-[80vh]` → `max-h-[80vh]` に変更し、コンテンツ量に応じたコンパクト表示に

### ラベル短縮
- `ja.json`: 入手先ラベルを短縮（ガシャ→恒常、コインガシャ→コイン、季節限定→季節、ユニット限定→ユニット、ライブツアー限定→ライブツアー）

## 確認事項

- [x] `npx tsc -p tsconfig.app.json --noEmit` エラーなし
- [x] `npm run lint` エラーなし
- [x] `npx knip --reporter compact` 不要コードなし
- [x] `npm test -- --run` 全テスト通過（1353 tests）
- [x] 動作確認済み
