### PR TITLE
fix(chore): agent-stop.sh の余分なクォートを修正

### DIFF
--- a/.github/hooks/scripts/agent-stop.sh
+++ b/.github/hooks/scripts/agent-stop.sh
@@ -22,7 +22,7 @@ if ! npx prettier --check "src/**/*.{ts,tsx}" 2>&1; then
 fi
 
 # --- 3. 型チェック ---
-echo "[3/3] 型チェック (tsc --noEmit) ...""
+echo "[3/3] 型チェック (tsc --noEmit) ..."
 if ! npx tsc -p tsconfig.app.json --noEmit 2>&1; then
   echo ""
   echo "⚠ コンパイルエラーがあります。修正してください。"


### PR DESCRIPTION
echo行の末尾に余分な`\"`があり、シェルスクリプトの構文エラーを引き起こしていた問題を修正。