### PR TITLE
feat(data): 新規サポートカード追加

### DIFF
--- a/src/data/json/cards.json
+++ b/src/data/json/cards.json
@@ -2746,8 +2746,8 @@
           "effect": {
             "use_condition": {
               "key": "keyword_eq",
-              "keyword": "vitality",
-              "value": 0
+              "value": 0,
+              "keyword": "vitality"
             },
             "groups": [
               {
@@ -2782,8 +2782,8 @@
           "effect": {
             "use_condition": {
               "key": "keyword_eq",
-              "keyword": "vitality",
-              "value": 0
+              "value": 0,
+              "keyword": "vitality"
             },
             "groups": [
               {
@@ -3257,6 +3257,105 @@
       "actions": [
         "enhance"
       ]
+    },
+    "skill_card": null
+  },
+  {
+    "name": "ひっぱりじゅーなん",
+    "rarity": "sr",
+    "plan": "anomaly",
+    "type": "vocal",
+    "parameter_type": "vocal",
+    "source": "unit_limited",
+    "release_date": "2026/04/01",
+    "abilities": [
+      {
+        "name_key": "initial_stat",
+        "trigger_key": "vo_initial_stat",
+        "parameter_type": "vocal",
+        "values": {},
+        "is_initial_stat": true
+      },
+      {
+        "name_key": "activity_supply_gift",
+        "trigger_key": "activity_supply_gift",
+        "parameter_type": "vocal",
+        "values": {}
+      },
+      {
+        "name_key": "support_rate",
+        "trigger_key": "support_rate",
+        "values": {},
+        "is_percentage": true,
+        "skip_calculation": true
+      },
+      {
+        "name_key": "reserve_card_acquire",
+        "trigger_key": "reserve_card_acquire",
+        "parameter_type": "vocal",
+        "values": {}
+      },
+      {
+        "name_key": "p_item_acquire",
+        "trigger_key": "p_item_acquire",
+        "parameter_type": "vocal",
+        "values": {},
+        "max_count": 6
+      },
+      {
+        "name_key": "event_boost",
+        "trigger_key": "event_boost",
+        "values": {},
+        "is_percentage": true,
+        "is_event_boost": true
+      }
+    ],
+    "events": [
+      {
+        "release": "initial",
+        "effect_type": "p_item",
+        "title": ""
+      },
+      {
+        "release": "lv20",
+        "effect_type": "param_boost",
+        "param_type": "vocal",
+        "param_value": 15,
+        "title": ""
+      }
+    ],
+    "p_item": {
+      "name": "切磋琢磨のタオル",
+      "rarity": "sr",
+      "memory": "memorizable",
+      "effect": {
+        "trigger": {
+          "key": "consult_selection"
+        },
+        "condition": {
+          "key": "param_gte",
+          "param": "vocal",
+          "threshold": 400
+        },
+        "body": [
+          {
+            "key": "param_up_pp",
+            "param": "vocal",
+            "count": 30,
+            "value": 30
+          }
+        ],
+        "limit": {
+          "key": "per_produce",
+          "count": 1
+        }
+      },
+      "boost": {
+        "trigger_key": "consult",
+        "parameter_type": "vocal",
+        "value": 30,
+        "max_count": 1
+      }
     },
     "skill_card": null
   },
@@ -6372,7 +6471,7 @@
         ]
       },
       "boost": {
-        "trigger_key": "lesson_end",
+        "trigger_key": "vo_lesson_end",
         "parameter_type": "vocal",
         "value": 13
       }
@@ -6473,7 +6572,7 @@
         }
       },
       "boost": {
-        "trigger_key": "sp_lesson_end",
+        "trigger_key": "vo_sp_lesson_end",
         "parameter_type": "vocal",
         "value": 20,
         "max_count": 2
@@ -7652,7 +7751,7 @@
         ]
       },
       "boost": {
-        "trigger_key": "lesson_end",
+        "trigger_key": "da_lesson_end",
         "parameter_type": "dance",
         "value": 13
       }
@@ -7937,7 +8036,7 @@
         ]
       },
       "boost": {
-        "trigger_key": "lesson_end",
+        "trigger_key": "vi_lesson_end",
         "parameter_type": "visual",
         "value": 13
       }
@@ -9035,6 +9134,103 @@
     }
   },
   {
+    "name": "騎士とおてんば姫",
+    "rarity": "sr",
+    "plan": "logic",
+    "type": "visual",
+    "parameter_type": "visual",
+    "source": "gacha",
+    "release_date": "2026/03/19",
+    "abilities": [
+      {
+        "name_key": "initial_stat",
+        "trigger_key": "vi_initial_stat",
+        "parameter_type": "visual",
+        "values": {},
+        "is_initial_stat": true
+      },
+      {
+        "name_key": "sp_lesson_rate",
+        "trigger_key": "vi_sp_lesson_rate",
+        "parameter_type": "visual",
+        "values": {},
+        "is_percentage": true,
+        "skip_calculation": true
+      },
+      {
+        "name_key": "support_rate",
+        "trigger_key": "support_rate",
+        "values": {},
+        "is_percentage": true,
+        "skip_calculation": true
+      },
+      {
+        "name_key": "skill_acquire",
+        "trigger_key": "skill_acquire",
+        "parameter_type": "visual",
+        "values": {}
+      },
+      {
+        "name_key": "sp_lesson_20",
+        "trigger_key": "sp_lesson_20",
+        "parameter_type": "visual",
+        "values": {},
+        "max_count": 4
+      },
+      {
+        "name_key": "event_boost",
+        "trigger_key": "event_boost",
+        "values": {},
+        "is_percentage": true,
+        "is_event_boost": true
+      }
+    ],
+    "events": [
+      {
+        "release": "initial",
+        "effect_type": "p_item",
+        "title": "役者としては大金星"
+      },
+      {
+        "release": "lv20",
+        "effect_type": "param_boost",
+        "param_type": "visual",
+        "param_value": 15,
+        "title": "ありのままのキミで"
+      }
+    ],
+    "p_item": {
+      "name": "演技のたしなみ",
+      "rarity": "sr",
+      "memory": "memorizable",
+      "effect": {
+        "restriction": {
+          "key": "lesson_turn",
+          "param": "visual"
+        },
+        "trigger": {
+          "key": "card_cost_hp_decrease"
+        },
+        "body": [
+          {
+            "key": "keyword_up",
+            "keyword": "good_impression",
+            "value": 2
+          },
+          {
+            "key": "hp_cost_reduce_turns",
+            "turns": 2
+          }
+        ],
+        "limit": {
+          "key": "per_lesson",
+          "count": 1
+        }
+      }
+    },
+    "skill_card": null
+  },
+  {
     "name": "魅惑の大腿四頭筋",
     "rarity": "sr",
     "plan": "free",
@@ -9268,6 +9464,7 @@
     "parameter_type": "vocal",
     "source": "event",
     "source_detail": "イベント「1年2組のアイドルたち」",
+    "is_event_source": true,
     "release_date": "2024/09/11",
     "abilities": [
       {
@@ -9360,8 +9557,7 @@
         }
       }
     },
-    "skill_card": null,
-    "is_event_source": true
+    "skill_card": null
   },
   {
     "name": "「ア」じゃなくて「エ」！",
@@ -11014,6 +11210,7 @@
     "parameter_type": "dance",
     "source": "event",
     "source_detail": "イベント「仲良し？三人組の日常」",
+    "is_event_source": true,
     "release_date": "2025/07/07",
     "abilities": [
       {
@@ -11106,8 +11303,7 @@
         }
       }
     },
-    "skill_card": null,
-    "is_event_source": true
+    "skill_card": null
   },
   {
     "name": "お疲れ様、千奈ちゃん。",
@@ -11651,6 +11847,7 @@
     "type": "vocal",
     "parameter_type": "vocal",
     "source": "coin_gacha",
+    "is_event_source": true,
     "release_date": "2024/05/16",
     "abilities": [
       {
@@ -11826,8 +12023,7 @@
           ]
         }
       ]
-    },
-    "is_event_source": true
+    }
   },
   {
     "name": "ここから始まるんだね！",
@@ -12133,6 +12329,7 @@
     "parameter_type": "vocal",
     "source": "event",
     "source_detail": "イベント「3年1組の修学旅行」",
+    "is_event_source": true,
     "release_date": "2025/04/11",
     "abilities": [
       {
@@ -12318,8 +12515,7 @@
           ]
         }
       ]
-    },
-    "is_event_source": true
+    }
   },
   {
     "name": "さみだれ",
@@ -12328,6 +12524,7 @@
     "type": "visual",
     "parameter_type": "visual",
     "source": "coin_gacha",
+    "is_event_source": true,
     "release_date": "2024/11/16",
     "abilities": [
       {
@@ -12501,8 +12698,7 @@
           ]
         }
       ]
-    },
-    "is_event_source": true
+    }
   },
   {
     "name": "すっかり仲良しって感じ♪",
@@ -12511,6 +12707,7 @@
     "type": "dance",
     "parameter_type": "dance",
     "source": "coin_gacha",
+    "is_event_source": true,
     "release_date": "2025/06/01",
     "abilities": [
       {
@@ -12595,8 +12792,7 @@
         }
       }
     },
-    "skill_card": null,
-    "is_event_source": true
+    "skill_card": null
   },
   {
     "name": "すっかり秋色ですわね！",
@@ -12706,6 +12902,7 @@
     "parameter_type": "vocal",
     "source": "event",
     "source_detail": "イベント「リーリヤと清夏の日常」",
+    "is_event_source": true,
     "release_date": "2025/11/10",
     "abilities": [
       {
@@ -12866,8 +13063,7 @@
           ]
         }
       ]
-    },
-    "is_event_source": true
+    }
   },
   {
     "name": "ぜったい追いついてやる！",
@@ -14459,6 +14655,7 @@
     "parameter_type": "vocal",
     "source": "event",
     "source_detail": "イベント「手毬と広の日常」",
+    "is_event_source": true,
     "release_date": "2026/01/27",
     "abilities": [
       {
@@ -14552,8 +14749,7 @@
         }
       }
     },
-    "skill_card": null,
-    "is_event_source": true
+    "skill_card": null
   },
   {
     "name": "みんなの意見を聞かせて♪",
@@ -14562,6 +14758,7 @@
     "type": "vocal",
     "parameter_type": "vocal",
     "source": "coin_gacha",
+    "is_event_source": true,
     "release_date": "2025/06/01",
     "abilities": [
       {
@@ -14645,8 +14842,7 @@
         }
       }
     },
-    "skill_card": null,
-    "is_event_source": true
+    "skill_card": null
   },
   {
     "name": "もうっ！　冷たいよ！",
@@ -15329,6 +15525,7 @@
     "type": "dance",
     "parameter_type": "dance",
     "source": "coin_gacha",
+    "is_event_source": true,
     "release_date": "2024/05/16",
     "abilities": [
       {
@@ -15507,8 +15704,7 @@
           ]
         }
       ]
-    },
-    "is_event_source": true
+    }
   },
   {
     "name": "わたしと美鈴、超仲良し",
@@ -15518,6 +15714,7 @@
     "parameter_type": "visual",
     "source": "event",
     "source_detail": "イベント「クラス対抗初星大運動会」",
+    "is_event_source": true,
     "release_date": "2025/05/16",
     "abilities": [
       {
@@ -15610,8 +15807,7 @@
         }
       }
     },
-    "skill_card": null,
-    "is_event_source": true
+    "skill_card": null
   },
   {
     "name": "オシャレもメイクも♪",
@@ -15621,6 +15817,7 @@
     "parameter_type": "visual",
     "source": "event",
     "source_detail": "イベント「ことねと麻央の日常」",
+    "is_event_source": true,
     "release_date": "2026/01/05",
     "abilities": [
       {
@@ -15716,8 +15913,7 @@
         }
       }
     },
-    "skill_card": null,
-    "is_event_source": true
+    "skill_card": null
   },
   {
     "name": "キラキラして綺麗～っ！",
@@ -16268,6 +16464,7 @@
     "parameter_type": "dance",
     "source": "event",
     "source_detail": "イベント「生徒会のアイドルたち」",
+    "is_event_source": true,
     "release_date": "2024/11/16",
     "abilities": [
       {
@@ -16359,8 +16556,7 @@
         }
       }
     },
-    "skill_card": null,
-    "is_event_source": true
+    "skill_card": null
   },
   {
     "name": "メリクリ、おねーちゃん♪",
@@ -17038,6 +17234,7 @@
     "parameter_type": "visual",
     "source": "shop",
     "source_detail": "ショップ「アイテム交換所（コンテスト）」",
+    "is_event_source": true,
     "release_date": "2024/05/16",
     "abilities": [
       {
@@ -17195,8 +17392,7 @@
           ]
         }
       ]
-    },
-    "is_event_source": true
+    }
   },
   {
     "name": "仲直りしましょう",
@@ -17206,6 +17402,7 @@
     "parameter_type": "vocal",
     "source": "shop",
     "source_detail": "ショップ「アイテム交換所（コンテスト）」",
+    "is_event_source": true,
     "release_date": "2025/08/01",
     "abilities": [
       {
@@ -17363,8 +17560,7 @@
           ]
         }
       ]
-    },
-    "is_event_source": true
+    }
   },
   {
     "name": "会長、準備は万端です",
@@ -18520,6 +18716,7 @@
               {
                 "action": {
                   "key": "next_card_cost_zero",
+                  "value": 0,
                   "count": 1
                 }
               },
@@ -18546,6 +18743,7 @@
               {
                 "action": {
                   "key": "next_card_cost_zero",
+                  "value": 0,
                   "count": 1
                 }
               },
@@ -19972,6 +20170,7 @@
     "parameter_type": "dance",
     "source": "event",
     "source_detail": "イベント「3年1組の日常」",
+    "is_event_source": true,
     "release_date": "2025/07/31",
     "abilities": [
       {
@@ -20061,8 +20260,7 @@
         }
       }
     },
-    "skill_card": null,
-    "is_event_source": true
+    "skill_card": null
   },
   {
     "name": "相変わらず不器用ね",
@@ -20435,6 +20633,7 @@
     "parameter_type": "visual",
     "source": "event",
     "source_detail": "イベント「1年1組のアイドルたち」",
+    "is_event_source": true,
     "release_date": "2024/05/22",
     "abilities": [
       {
@@ -20617,8 +20816,7 @@
           ]
         }
       ]
-    },
-    "is_event_source": true
+    }
   },
   {
     "name": "絶対にお渡ししますわっ！",
@@ -20994,6 +21192,7 @@
     "parameter_type": "visual",
     "source": "event",
     "source_detail": "イベント「星南と燕の日常」",
+    "is_event_source": true,
     "release_date": "2025/11/28",
     "abilities": [
       {
@@ -21083,8 +21282,7 @@
         }
       }
     },
-    "skill_card": null,
-    "is_event_source": true
+    "skill_card": null
   },
   {
     "name": "迷子のおしらせです",
@@ -21093,6 +21291,7 @@
     "type": "visual",
     "parameter_type": "visual",
     "source": "coin_gacha",
+    "is_event_source": true,
     "release_date": "2025/06/01",
     "abilities": [
       {
@@ -21176,8 +21375,204 @@
         }
       }
     },
-    "skill_card": null,
-    "is_event_source": true
+    "skill_card": null
+  },
+  {
+    "name": "進化したお弁当、気になる",
+    "rarity": "ssr",
+    "plan": "logic",
+    "type": "visual",
+    "parameter_type": "visual",
+    "source": "gacha",
+    "release_date": "2026/03/19",
+    "abilities": [
+      {
+        "name_key": "parameter_bonus",
+        "trigger_key": "vi_parameter_bonus",
+        "parameter_type": "visual",
+        "values": {},
+        "is_percentage": true,
+        "is_parameter_bonus": true
+      },
+      {
+        "name_key": "sp_lesson_end",
+        "trigger_key": "vi_sp_lesson_end",
+        "parameter_type": "visual",
+        "values": {}
+      },
+      {
+        "name_key": "support_rate",
+        "trigger_key": "support_rate",
+        "values": {},
+        "is_percentage": true,
+        "skip_calculation": true
+      },
+      {
+        "name_key": "p_item_acquire",
+        "trigger_key": "p_item_acquire",
+        "parameter_type": "visual",
+        "values": {},
+        "max_count": 6
+      },
+      {
+        "name_key": "activity_supply_gift",
+        "trigger_key": "activity_supply_gift",
+        "parameter_type": "visual",
+        "values": {}
+      },
+      {
+        "name_key": "event_boost",
+        "trigger_key": "event_boost",
+        "values": {},
+        "is_percentage": true,
+        "is_event_boost": true
+      }
+    ],
+    "events": [
+      {
+        "release": "initial",
+        "effect_type": "p_item",
+        "title": "もうひとりの妹？"
+      },
+      {
+        "release": "lv20",
+        "effect_type": "param_boost",
+        "param_type": "visual",
+        "param_value": 20,
+        "title": "あいさつしてもいい？"
+      },
+      {
+        "release": "lv40",
+        "effect_type": "card_enhance",
+        "title": "料理を美味しくするもの"
+      }
+    ],
+    "p_item": {
+      "name": "咲季の完全食・改",
+      "rarity": "ssr",
+      "memory": "memorizable",
+      "effect": {
+        "trigger": {
+          "key": "card_use_count_in_turn",
+          "count": 2
+        },
+        "body": [
+          {
+            "key": "keyword_up",
+            "keyword": "good_impression",
+            "value": 2
+          },
+          {
+            "key": "keyword_enhance_pct",
+            "keyword": "good_impression",
+            "value": 25
+          }
+        ],
+        "limit": {
+          "key": "per_lesson",
+          "count": 1
+        }
+      }
+    },
+    "skill_card": null
+  },
+  {
+    "name": "長旅おつかれさま！",
+    "rarity": "ssr",
+    "plan": "sense",
+    "type": "visual",
+    "parameter_type": "visual",
+    "source": "unit_limited",
+    "release_date": "2026/04/01",
+    "abilities": [
+      {
+        "name_key": "initial_stat",
+        "trigger_key": "vi_initial_stat",
+        "parameter_type": "visual",
+        "values": {},
+        "is_initial_stat": true
+      },
+      {
+        "name_key": "sp_lesson_rate",
+        "trigger_key": "vi_sp_lesson_rate",
+        "parameter_type": "visual",
+        "values": {},
+        "is_percentage": true,
+        "skip_calculation": true
+      },
+      {
+        "name_key": "support_rate",
+        "trigger_key": "support_rate",
+        "values": {},
+        "is_percentage": true,
+        "skip_calculation": true
+      },
+      {
+        "name_key": "good_condition_card_acquire",
+        "trigger_key": "good_condition_card_acquire",
+        "parameter_type": "visual",
+        "values": {}
+      },
+      {
+        "name_key": "sp_lesson_20",
+        "trigger_key": "sp_lesson_20",
+        "parameter_type": "visual",
+        "values": {},
+        "max_count": 4
+      },
+      {
+        "name_key": "event_boost",
+        "trigger_key": "event_boost",
+        "values": {},
+        "is_percentage": true,
+        "is_event_boost": true
+      }
+    ],
+    "events": [
+      {
+        "release": "initial",
+        "effect_type": "p_item",
+        "title": ""
+      },
+      {
+        "release": "lv20",
+        "effect_type": "param_boost",
+        "param_type": "visual",
+        "param_value": 20,
+        "title": ""
+      },
+      {
+        "release": "lv40",
+        "effect_type": "card_enhance",
+        "title": ""
+      }
+    ],
+    "p_item": {
+      "name": "夢を叶えるために",
+      "rarity": "ssr",
+      "memory": "memorizable",
+      "effect": {
+        "restriction": {
+          "key": "lesson_turn",
+          "param": "visual"
+        },
+        "trigger": {
+          "key": "turn_start"
+        },
+        "condition": {
+          "key": "excluded_cards_gte",
+          "threshold": 7
+        },
+        "body": [
+          {
+            "key": "keyword_turns",
+            "keyword": "good_condition",
+            "turns": 1
+          }
+        ]
+      }
+    },
+    "skill_card": null
   },
   {
     "name": "食欲の秋なんです",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -241,7 +241,9 @@
       "turn_start_after": "ターン開始後、",
       "active_card_use": "アクティブスキルカード使用時、",
       "card_use": "スキルカード使用時、",
-      "motivation_increase_after": "直接効果でやる気が増加後、"
+      "motivation_increase_after": "直接効果でやる気が増加後、",
+      "card_use_count_in_turn": "ターン内にスキルカードを{{count}}回使用時、",
+      "card_cost_hp_decrease": "スキルカードコストで体力減少時、"
     },
     "pitem_condition": {
       "param_gte": "{{param}}が{{threshold}}以上の場合、",
@@ -252,7 +254,8 @@
       "hp_lte_pct": "体力が{{threshold}}％以下の場合、",
       "keyword_count_gte": "{{keyword}}になった回数が{{threshold}}回以上の場合、",
       "policy_change_gte": "指針を変更した回数が{{threshold}}回以上の場合、",
-      "prev_active_card": "直前にアクティブスキルカードを使用した状態の場合、"
+      "prev_active_card": "直前にアクティブスキルカードを使用した状態の場合、",
+      "excluded_cards_gte": "除外にあるスキルカードが{{threshold}}枚以上の場合、"
     },
     "pitem_body": {
       "param_up": "{{param}}上昇+{{value}}",
@@ -308,7 +311,10 @@
       "pp_hp_recovery": "Pポイント+{{value}}体力回復{{count}}",
       "random_enhance_pp": "ランダムなスキルカードを強化Pポイント+{{value}}",
       "random_enhance_hp": "ランダムなスキルカードを強化体力回復{{value}}",
-      "acquire_item_pp": "{{item_name}}を獲得Pポイント+{{value}}"
+      "acquire_item_pp": "{{item_name}}を獲得Pポイント+{{value}}",
+      "keyword_enhance_pct": "{{keyword}}強化+{{value}}％",
+      "hp_cost_reduce_turns": "消費体力減少{{turns}}ターン",
+      "keyword_turns": "{{keyword}}{{turns}}ターン"
     },
     "pitem_limit": {
       "per_produce": "（プロデュース中{{count}}回）",


### PR DESCRIPTION
## 概要
新規サポートカード4枚を追加しました。

## 変更内容
- 新規サポートカード追加
  - 進化したお弁当、気になる (SSR)
  - 騎士とおてんば姫 (SR)
  - 長旅おつかれさま！ (SSR)
  - ひっぱりじゅーなん (SR)
- Pアイテム効果の新パターン対応（i18nキー追加）
- trigger_keyの精度向上

## 確認事項
- [x] 動作確認済み
