### PR TITLE
fix(unit): レンタル枠判定でシナジー込みのユニットスコアを使用する

### DIFF
--- a/src/__tests__/utils/unitSimulator.test.ts
+++ b/src/__tests__/utils/unitSimulator.test.ts
@@ -8,11 +8,12 @@ import { evaluateManualUnit, optimizeUnit } from '../../utils/unitSimulator'
 import { calculateCardParameter } from '../../utils/calculator/calculateCard'
 import { computeUnitSupportSynergy, getProvidedActions } from '../../utils/supportSynergy'
 import { getSelfAcquisitionBonus } from '../../utils/calculator/events'
-import { AllCards, getScheduleData, TriggerActionMap } from '../../data'
+import { ActionCategoryList, AllCards, getScheduleData, TriggerActionMap } from '../../data'
 import { mergeScheduleCounts } from '../../utils/scoreSettings'
 import type { ScoreSettings } from '../../types/card'
 import * as enums from '../../types/enums'
 import type { UnitSimulatorSettings } from '../../types/unit'
+import * as constant from '../../constant'
 
 /** デフォルトのスコア設定を作る */
 function makeScoreSettings(overrides: Partial<ScoreSettings> = {}): ScoreSettings {
@@ -27,6 +28,34 @@ function makeScoreSettings(overrides: Partial<ScoreSettings> = {}): ScoreSetting
     includePItem: true,
     parameterBonusBase: { vocal: 0, dance: 0, visual: 0 },
     actionCounts: {},
+    ...overrides,
+  }
+}
+
+/** スケジュール込みのスコア設定を作る（実際のアプリと同じデフォルト） */
+function makeRealisticScoreSettings(overrides: Partial<ScoreSettings> = {}): ScoreSettings {
+  const actionCounts: Partial<Record<enums.ActionIdType, number>> = {}
+  for (const cat of ActionCategoryList) {
+    actionCounts[cat.id] = 0
+  }
+  const scheduleData = getScheduleData(constant.DEFAULT_SCENARIO, constant.DEFAULT_DIFFICULTY)
+  const scheduleSelections: Record<number, enums.ActivityIdType> = {}
+  for (const week of scheduleData) {
+    if (week.fixed && !week.canRest && week.activities.length > 0) {
+      scheduleSelections[week.week] = week.activities[0].id
+    }
+  }
+  return {
+    name: 'realistic',
+    scenario: constant.DEFAULT_SCENARIO,
+    difficulty: constant.DEFAULT_DIFFICULTY,
+    parameterBonusBase: { vocal: 0, dance: 0, visual: 0 },
+    actionCounts,
+    scheduleSelections,
+    useScheduleLimits: true,
+    includeSelfTrigger: true,
+    includePItem: true,
+    useFixedUncap: false,
     ...overrides,
   }
 }
@@ -460,6 +489,54 @@ describe('最適編成', () => {
       const manual = evaluateManualUnit({ settings: manualSettings, scoreSettings: uncapSettings, cardUncaps })
       expect(manual).not.toBeNull()
       expect(manual!.totalScore).toBe(result.totalScore)
+    })
+
+    it('低凸メンバーが多い場合も0凸で入るカードがNotOwnedでレンタルとして入る', () => {
+      // 低凸メンバーが多い環境で、0凸で選出されるカードは NotOwned でもレンタルとして選出される
+      // スケジュール込みのリアルな設定を使うことでサポート間連携の影響を再現する
+      const plan = enums.PlanType.Anomaly
+      const settings = makeSimulatorSettings([], {
+        plan,
+        manualCards: [],
+        spConstraint: { vocal: 0, dance: 0, visual: 0 },
+      })
+
+      // リアルなスコア設定でベースラインを取得し、全メンバーを2凸に設定する
+      const baseline = optimizeUnit({
+        settings,
+        scoreSettings: makeRealisticScoreSettings({ useFixedUncap: true }),
+        cardUncaps: {},
+      })
+      if (!baseline) return
+
+      const cardUncaps: Record<string, enums.UncapType> = {}
+      for (const m of baseline.members) {
+        cardUncaps[m.card.name] = enums.UncapType.Two
+      }
+
+      const scoreSettings = makeRealisticScoreSettings()
+
+      // 各ベースラインメンバーについて「0凸で入る → NotOwnedでもレンタルとして入る」を検証する
+      for (const member of baseline.members) {
+        const target = member.card.name
+
+        // 0凸で最適化し、ターゲットが選出されるか確認する
+        const uncapsZero = { ...cardUncaps, [target]: enums.UncapType.Zero }
+        const resultZero = optimizeUnit({ settings, scoreSettings, cardUncaps: uncapsZero })
+        if (!resultZero) continue
+        const inZero = resultZero.members.some((m) => m.card.name === target)
+        if (!inZero) continue // 0凸で入らない場合はスキップ
+
+        // NotOwnedで最適化する
+        const uncapsNotOwned = { ...cardUncaps, [target]: enums.UncapType.NotOwned }
+        const resultNotOwned = optimizeUnit({ settings, scoreSettings, cardUncaps: uncapsNotOwned })
+        expect(resultNotOwned).not.toBeNull()
+        if (!resultNotOwned) continue
+
+        // 0凸で選出されるカードは NotOwned でもレンタルとして選出されるべき
+        const inNotOwned = resultNotOwned.members.some((m) => m.card.name === target)
+        expect(inNotOwned, `${target}: 0凸で選出されるが NotOwned で選出されない`).toBe(true)
+      }
     })
   })
 

--- a/src/utils/unitSimulator.ts
+++ b/src/utils/unitSimulator.ts
@@ -404,13 +404,16 @@ function autoDesignateRental(
 ): { members: CandidateCard[]; rentalName: string | null } {
   if (members.length === 0) return { members, rentalName: null }
 
+  // 現在のユニットスコア（シナジー込み）をベースラインとする
+  const currentScore = evaluateUnit(members, input)
+
   // 4凸でないサポートを仮に4凸で再計算し、最もスコア向上が大きいサポートをレンタルに指定
   const { scoreSettings } = input
   const { effectiveCounts, perLessonValues } = resolveSchedule(scoreSettings)
 
-  // 4凸でないサポートの中から最も恩恵の大きいサポートを選ぶ
+  // 4凸でないサポートの中から最も恩恵の大きいサポートを選ぶ（シナジー込みで評価）
+  let bestUpgradeScore = -Infinity
   let bestUpgradeIdx = -1
-  let bestUpgradeGain = -Infinity
   let bestUpgradeResult: CardCalculationResult | null = null
 
   for (let i = 0; i < members.length; i++) {
@@ -429,18 +432,27 @@ function autoDesignateRental(
       customData?.selfTrigger,
       customData?.pItemCount,
     )
-    const gain = result4.totalIncrease - m.baseScore
-    if (gain > bestUpgradeGain) {
-      bestUpgradeGain = gain
+    // シナジーを含むユニット全体スコアで評価する
+    const trial = [...members]
+    trial[i] = {
+      ...m,
+      uncap: enums.UncapType.Four,
+      baseScore: result4.totalIncrease,
+      baseResult: result4,
+      paramBonusPercent: getParamBonusPercent(m.card, enums.UncapType.Four),
+    }
+    const trialScore = evaluateUnit(trial, input)
+    if (trialScore > bestUpgradeScore) {
+      bestUpgradeScore = trialScore
       bestUpgradeIdx = i
       bestUpgradeResult = result4
     }
   }
 
-  // 未所持サポートの4凸スワップを検討する
+  // 未所持サポートの4凸スワップを検討する（シナジー込みで評価）
   const lockedNames = new Set(input.settings.lockedCards)
   const memberNames = new Set(members.map((m) => m.card.name))
-  let bestSwapGain = -Infinity
+  let bestSwapScore = -Infinity
   let bestSwapMemberIdx = -1
   let bestSwapCandidate: CandidateCard | null = null
 
@@ -448,23 +460,22 @@ function autoDesignateRental(
     if (memberNames.has(unowned.card.name)) continue
     for (let i = 0; i < members.length; i++) {
       if (lockedNames.has(members[i].card.name)) continue
-      const swapGain = unowned.baseScore - members[i].baseScore
-      if (swapGain > bestSwapGain) {
-        const trial = [...members]
-        trial[i] = unowned
-        if (meetsSpConstraint(trial, input.settings.spConstraint)) {
-          bestSwapGain = swapGain
-          bestSwapMemberIdx = i
-          bestSwapCandidate = unowned
-        }
+      const trial = [...members]
+      trial[i] = unowned
+      if (!meetsSpConstraint(trial, input.settings.spConstraint)) continue
+      const trialScore = evaluateUnit(trial, input)
+      if (trialScore > bestSwapScore) {
+        bestSwapScore = trialScore
+        bestSwapMemberIdx = i
+        bestSwapCandidate = unowned
       }
     }
   }
 
-  // 4凸でないサポートがあれば4凸昇格と未所持スワップのうちゲインが大きい方を選ぶ
+  // 4凸でないサポートがあれば4凸昇格と未所持スワップのうちスコアが高い方を選ぶ
   if (bestUpgradeIdx >= 0 && bestUpgradeResult) {
-    if (bestSwapGain > 0 && bestSwapGain > bestUpgradeGain && bestSwapCandidate && bestSwapMemberIdx >= 0) {
-      // 未所持サポートのスワップの方がゲインが大きい
+    if (bestSwapScore > bestUpgradeScore && bestSwapCandidate && bestSwapMemberIdx >= 0) {
+      // 未所持サポートのスワップの方がユニットスコアが高い
       const updated = [...members]
       updated[bestSwapMemberIdx] = bestSwapCandidate
       return { members: updated, rentalName: bestSwapCandidate.card.name }
@@ -482,7 +493,7 @@ function autoDesignateRental(
   }
 
   // 全員4凸の場合: 未所持スワップを検討する
-  if (bestSwapGain > 0 && bestSwapCandidate && bestSwapMemberIdx >= 0) {
+  if (bestSwapScore > currentScore && bestSwapCandidate && bestSwapMemberIdx >= 0) {
     const updated = [...members]
     updated[bestSwapMemberIdx] = bestSwapCandidate
     return { members: updated, rentalName: bestSwapCandidate.card.name }


### PR DESCRIPTION
## 概要

未所持サポートのレンタル枠判定で、個別baseScoreではなくシナジー込みチーム全体スコア（evaluateUnit）を使用するように修正。
PR #19 で追加されたレンタルスワップ機構の比較方法の不具合を修正。

Closes #18

## 変更内容

- `autoDesignateRental` の4凸昇格/未所持スワップの比較ロジックを `baseScore` 差分から `evaluateUnit`（シナジー込みチーム全体スコア）に変更
- 低凸環境で「0凸=選出/未所持=非選出」となるバグの回帰テストを追加（`makeRealisticScoreSettings` でスケジュール込みの設定を使用）

### 根本原因

`autoDesignateRental` は個別カードの `baseScore`（シナジーなし）で昇格とスワップを比較していたが、`localSearch` は `evaluateUnit`（シナジー込み）で評価していた。このミスマッチにより、シナジーが重要なカードが0凸では選出されるのに未所持では選出されないケースが発生していた。

## 確認事項
- [x] 動作確認済み
- [x] 修正前にテスト失敗、修正後に通過することを確認
- [x] 全1410テスト通過