### PR TITLE
fix: PageSpeed Insightsの指摘事項を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; img-src 'self' https://*.google-analytics.com https://*.googletagmanager.com; style-src 'self' 'unsafe-inline';" />
     <meta name="theme-color" content="#fafafa" />
+    <link rel="preconnect" href="https://www.googletagmanager.com" />
+    <link rel="preconnect" href="https://www.google-analytics.com" />
     <meta name="description" content="学園アイドルマスター（学マス）のサポートカード点数を自動計算。サポカの比較・最適編成シミュレーターで効率的に編成を組めます。" />
     <link rel="canonical" href="%VITE_SITE_URL%" />
     <meta property="og:title" content="学マス サポカ点数計算・比較ツール | 学ナビ" />

--- a/src/components/filterBar/SortControls.tsx
+++ b/src/components/filterBar/SortControls.tsx
@@ -59,7 +59,7 @@ export default function SortControls({
         <div className="text-center mb-1 sm:hidden">
           <button
             onClick={onOpenScoreSettings}
-            className="text-[10px] text-blue-400 hover:text-blue-600 transition-colors cursor-pointer"
+            className="text-[10px] text-blue-500 hover:text-blue-600 transition-colors cursor-pointer"
           >
             {t('ui.message.score_settings_hint')}
           </button>
@@ -67,14 +67,14 @@ export default function SortControls({
       )}
       <div className="flex items-center justify-between">
         {/* 左: 表示件数 */}
-        <p className="text-xs font-medium text-slate-500">
+        <p className="text-xs font-medium text-slate-600">
           {count} {t('ui.unit.cards')}
         </p>
         {/* PC: ヒントを中央に表示 */}
         {!scheduleConfigured && !scoreSettingsVisible && (
           <button
             onClick={onOpenScoreSettings}
-            className="hidden sm:block text-[10px] text-blue-400 hover:text-blue-600 transition-colors cursor-pointer"
+            className="hidden sm:block text-[10px] text-blue-500 hover:text-blue-600 transition-colors cursor-pointer"
           >
             {t('ui.message.score_settings_hint')}
           </button>

--- a/src/components/scoreSettingsPanel/ActionCountsSection.tsx
+++ b/src/components/scoreSettingsPanel/ActionCountsSection.tsx
@@ -65,7 +65,7 @@ export function ActionCountsSection({
                   >
                     {/* アクション名（例: 「ボーカルレッスン」「おでかけ」「休む」） */}
                     {t(cat.label)}
-                    {isControlled && <span className="ml-1 text-[9px] text-blue-400">{t('ui.settings.auto')}</span>}
+                    {isControlled && <span className="ml-1 text-[9px] text-blue-500">{t('ui.settings.auto')}</span>}
                   </label>
                   {/* 数値入力: スケジュール自動計算有効時は自動値で固定され操作不可 */}
                   <SpinnerInput

--- a/src/constant/styles.ts
+++ b/src/constant/styles.ts
@@ -7,10 +7,10 @@
  */
 
 /** フィルターセクションラベル（10px） */
-export const FILTER_SECTION_LABEL = 'text-[10px] font-bold text-slate-500 uppercase tracking-wider mb-1.5'
+export const FILTER_SECTION_LABEL = 'text-[10px] font-bold text-slate-600 uppercase tracking-wider mb-1.5'
 
 /** セクション見出し（小・パディング付き） */
-export const SECTION_HEADING_SM_PX = 'text-[10px] font-black text-slate-500 uppercase tracking-widest mb-1 px-1'
+export const SECTION_HEADING_SM_PX = 'text-[10px] font-black text-slate-600 uppercase tracking-widest mb-1 px-1'
 
 /** テキスト入力（小、角丸XL） */
 export const INPUT_TEXT_XS =
@@ -52,7 +52,7 @@ export const DROPDOWN_PANEL =
 
 /** アビリティバッジ（グリッドサポート用） */
 export const BADGE_ABILITY_GRID =
-  'px-1 py-0.5 rounded-full text-[8px] font-bold bg-slate-100 text-slate-500 border border-slate-200 whitespace-nowrap shrink-0'
+  'px-1 py-0.5 rounded-full text-[8px] font-bold bg-slate-100 text-slate-600 border border-slate-200 whitespace-nowrap shrink-0'
 
 /** フィルターグループ間の縦線 */
 export const FILTER_SEPARATOR = 'w-px h-5 bg-slate-200'
@@ -61,7 +61,7 @@ export const FILTER_SEPARATOR = 'w-px h-5 bg-slate-200'
 export const SECTION_DIVIDER = 'border-t border-slate-200 pt-3'
 
 /** トグルボタン: 非活性状態 */
-export const BTN_TOGGLE_INACTIVE = 'bg-slate-100 text-slate-500 hover:bg-slate-200'
+export const BTN_TOGGLE_INACTIVE = 'bg-slate-100 text-slate-600 hover:bg-slate-200'
 
 /** トグルボタン: 活性状態 */
 export const BTN_TOGGLE_ACTIVE = 'bg-slate-900 text-white'
@@ -97,7 +97,7 @@ export const SPINNER_INPUT =
 export const CHECKBOX_INPUT = 'w-3.5 h-3.5 rounded border-slate-300 text-blue-500 focus:ring-blue-500'
 
 /** セクションラベル（フォーム用） */
-export const FORM_SECTION_LABEL = 'text-xs font-bold text-slate-500 mb-1.5 flex items-center gap-1.5'
+export const FORM_SECTION_LABEL = 'text-xs font-bold text-slate-600 mb-1.5 flex items-center gap-1.5'
 
 /** SSR のバッジグラデーション */
 export const RARITY_COLOR_SSR = 'bg-gradient-to-r from-rose-400 via-amber-300 to-sky-400 text-white'

--- a/src/data/card/badge.ts
+++ b/src/data/card/badge.ts
@@ -31,7 +31,7 @@ interface PlanBadgeEntry {
 
 const memoryBadgeEntries: MemoryBadgeEntry[] = [
   { id: PItemMemoryType.Memorizable, label: 'card.memory.memorizable', badge: 'bg-emerald-100 text-emerald-700' },
-  { id: PItemMemoryType.NonMemorizable, label: 'card.memory.non_memorizable', badge: 'bg-slate-200 text-slate-500' },
+  { id: PItemMemoryType.NonMemorizable, label: 'card.memory.non_memorizable', badge: 'bg-slate-200 text-slate-600' },
 ]
 
 const skillTypeBadgeEntries: SkillTypeBadgeEntry[] = [

--- a/src/data/card/sourceDisplay.ts
+++ b/src/data/card/sourceDisplay.ts
@@ -22,7 +22,7 @@ const entries: SourceDisplayEntry[] = [
   { id: SourceType.LiveTourLimited, label: 'card.source.live_tour_limited', badge: 'bg-purple-100 text-purple-700' },
   { id: SourceType.HatsuboshiFes, label: 'card.source.hatsuboshi_fes', badge: 'bg-orange-100 text-orange-700' },
   { id: SourceType.Event, label: 'card.source.event', badge: 'bg-cyan-100 text-cyan-700' },
-  { id: SourceType.Initial, label: 'card.source.initial', badge: 'bg-slate-100 text-slate-500' },
+  { id: SourceType.Initial, label: 'card.source.initial', badge: 'bg-slate-100 text-slate-600' },
   { id: SourceType.Shop, label: 'card.source.shop', badge: 'bg-emerald-100 text-emerald-700' },
   { id: SourceType.Pack, label: 'card.source.pack', badge: 'bg-rose-100 text-rose-700' },
 ]

--- a/src/data/card/typeDisplay.ts
+++ b/src/data/card/typeDisplay.ts
@@ -53,7 +53,7 @@ export const TypeDisplayEntries: readonly TypeDisplayEntry[] = [
     label: 'common.type.short.visual',
     displayLabel: 'common.type.visual',
     parameterType: ParameterType.Visual,
-    text: 'text-yellow-600',
+    text: 'text-yellow-700',
     bg: 'bg-yellow-50',
     border: 'border-yellow-200',
     badge: 'bg-yellow-500 text-white',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,9 +37,11 @@ export default defineConfig(({ mode }) => {
         manifest: false,
         scope: basePath,
         registerType: 'autoUpdate',
+        injectRegister: 'script-defer',
         workbox: {
           skipWaiting: true,
           clientsClaim: true,
+          navigateFallbackDenylist: [/\/(sitemap\.xml|robots\.txt)$/],
         },
       }),
     ],


### PR DESCRIPTION
## 概要

PageSpeed Insightsで指摘されたパフォーマンス・アクセシビリティの問題を修正する。

## 変更内容

- テキストカラーのコントラスト比をWCAG AA基準に修正（`text-slate-500`→`600`、`text-blue-400`→`500`、`text-yellow-600`→`700`）
- Google Analytics向け `<link rel="preconnect">` を追加してLCP改善
- Service Worker登録スクリプトを `script-defer` に変更してレンダリングブロックを解消
- workboxの `navigateFallbackDenylist` を追加し、sitemap.xml・robots.txtがSWによりindex.htmlにフォールバックされる問題を修正

## 確認事項
- [x] 動作確認済み
