### PR TITLE
fix(ui): iPhoneのsafe-area対応・dvhビューポート修正・遅延プリフェッチ

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; img-src 'self' https://*.google-analytics.com https://*.googletagmanager.com; style-src 'self' 'unsafe-inline';" />
     <meta name="theme-color" content="#fafafa" />
     <link rel="preconnect" href="https://www.googletagmanager.com" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,23 @@ function App() {
   const { t } = useTranslation()
   const state = useAppState()
 
+  // アイドル時に遅延チャンクをプリフェッチ（モーダル操作時の読み込み待ちを解消）
+  useEffect(() => {
+    const preload = () => {
+      import('./components/cardDetailModal/CardDetailModal')
+      import('./components/scoreDetailModal/ScoreDetailModal')
+      import('./components/scoreSettingsPanel/ScoreSettingsPanel')
+      import('./components/filterBar/FilterSortModal')
+      import('./components/unitSimulator/UnitSimulatorPanel')
+    }
+    if ('requestIdleCallback' in window) {
+      const id = requestIdleCallback(preload)
+      return () => cancelIdleCallback(id)
+    }
+    const timer = setTimeout(preload, 2000)
+    return () => clearTimeout(timer)
+  }, [])
+
   // サポート一覧選択モード: UnitSimulatorPanel が登録する addCard コールバック
   const addManualCardRef = useRef<((cardName: string) => void) | null>(null)
   const registerAddManualCard = useCallback((fn: ((cardName: string) => void) | null) => {
@@ -155,7 +172,7 @@ function App() {
           </footer>
           {/* サポート一覧選択モード: フローティングバー */}
           {state.ui.unitCardSelectMode && (
-            <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 bg-blue-600 text-white px-5 py-3 rounded-2xl shadow-lg">
+            <div className="fixed bottom-[max(1rem,env(safe-area-inset-bottom))] left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 bg-blue-600 text-white px-5 py-3 rounded-2xl shadow-lg">
               <span className="text-xs font-bold">{t('unit.manual_select_bar')}</span>
               <button
                 onClick={() => {

--- a/src/components/header/AppHeader.tsx
+++ b/src/components/header/AppHeader.tsx
@@ -6,7 +6,7 @@
  * データ管理パネル、モバイルメニューを含む。
  */
 import { useTranslation } from 'react-i18next'
-import { useState, lazy, Suspense } from 'react'
+import { useState, useEffect, lazy, Suspense } from 'react'
 import { useCardUIContext } from '../../contexts/CardContext'
 import * as constant from '../../constant'
 import { getFilterButtonStyle } from '../../data/ui'
@@ -53,6 +53,20 @@ export default function AppHeader({
   const { uncapEditMode, onToggleUncapEdit } = useCardUIContext()
   const [helpOpen, setHelpOpen] = useState(false)
   const [aboutOpen, setAboutOpen] = useState(false)
+
+  // アイドル時にモーダルチャンクをプリフェッチ
+  useEffect(() => {
+    const preload = () => {
+      import('../helpModal/HelpModal')
+      import('../aboutModal/AboutModal')
+    }
+    if ('requestIdleCallback' in window) {
+      const id = requestIdleCallback(preload)
+      return () => cancelIdleCallback(id)
+    }
+    const timer = setTimeout(preload, 2000)
+    return () => clearTimeout(timer)
+  }, [])
 
   // ヘッダーボタンのスタイル
   const activeStyle = getFilterButtonStyle(FilterButtonCategory.Active)

--- a/src/components/ui/ModalOverlay.tsx
+++ b/src/components/ui/ModalOverlay.tsx
@@ -53,7 +53,10 @@ export default function ModalOverlay({
   }, [handleKeyDown])
 
   return (
-    <div className={`fixed inset-0 z-50 flex ${getModalAlignClass(align)} p-4 ${className}`} onClick={onClose}>
+    <div
+      className={`fixed inset-0 z-50 flex ${getModalAlignClass(align)} px-4 pb-[max(1rem,env(safe-area-inset-bottom))] pt-[max(1rem,env(safe-area-inset-top))] ${className}`}
+      onClick={onClose}
+    >
       {/* 半透明の背景 */}
       <div className={MODAL_BACKDROP} />
       {/* stopPropagation でモーダル内側のクリックが背景に伝わらないようにする */}

--- a/src/components/ui/SidePanelLayout.tsx
+++ b/src/components/ui/SidePanelLayout.tsx
@@ -52,7 +52,10 @@ export function SidePanelLayout({ isOpen, onClose, pinned, secondPanel, children
 
   // オーバーレイ: 背景クリックでも閉じる
   return (
-    <div className="fixed inset-0 z-50 flex justify-end" onClick={onClose}>
+    <div
+      className="fixed inset-0 z-50 flex justify-end pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]"
+      onClick={onClose}
+    >
       <div className={constant.MODAL_BACKDROP} />
       <div ref={panelRef} onClick={(e) => e.stopPropagation()} className={constant.PANEL_OVERLAY}>
         {children}

--- a/src/constant/styles.ts
+++ b/src/constant/styles.ts
@@ -76,15 +76,16 @@ export const INPUT_LOCKED = 'bg-blue-50 border-blue-200 text-blue-600 cursor-not
 export const MODAL_BACKDROP = 'absolute inset-0 bg-black/40 backdrop-blur-sm'
 
 /** モーダル白パネル（サポート詳細用） */
-export const MODAL_PANEL_DETAIL = 'relative bg-white rounded-2xl shadow-2xl max-w-2xl w-full h-[90vh] overflow-y-auto'
+export const MODAL_PANEL_DETAIL =
+  'relative bg-white rounded-2xl shadow-2xl max-w-2xl w-full h-[90vh] h-[90dvh] overflow-y-auto'
 
 /** モーダル白パネル（スコア内訳用） */
 export const MODAL_PANEL_SCORE =
-  'relative bg-white rounded-2xl shadow-2xl max-w-md w-full max-h-[80vh] flex flex-col overflow-hidden'
+  'relative bg-white rounded-2xl shadow-2xl max-w-md w-full max-h-[80vh] max-h-[80dvh] flex flex-col overflow-hidden'
 
 /** モーダル白パネル（フィルタ・ソート用） */
 export const MODAL_PANEL_FILTER =
-  'relative bg-white rounded-2xl shadow-2xl max-w-md w-full h-[85vh] flex flex-col overflow-hidden'
+  'relative bg-white rounded-2xl shadow-2xl max-w-md w-full h-[85vh] h-[85dvh] flex flex-col overflow-hidden'
 
 /** SpinnerInput: +/- ボタン（通常時） */
 export const SPINNER_BTN = 'w-6 h-6 flex items-center justify-center rounded text-xs font-bold'

--- a/src/index.css
+++ b/src/index.css
@@ -9,11 +9,17 @@
 body {
   margin: 0;
   min-height: 100vh;
+  min-height: 100dvh;
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 @keyframes slide-in-right {
-  from { transform: translateX(100%); }
-  to { transform: translateX(0); }
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
 }
 
 .animate-slide-in-right {


### PR DESCRIPTION
## 概要
iPhoneでモーダルの×ボタンがブラウザバーに隠れる問題と画面下部が切れる問題を修正し、遅延チャンクのプリフェッチを追加。

## 変更内容
### safe-area対応 & dvhビューポート
- `viewport-fit=cover` を `index.html` に追加
- `ModalOverlay` / `SidePanelLayout` に `env(safe-area-inset-top)` / `env(safe-area-inset-bottom)` パディング追加
- `vh` → `dvh`（フォールバック付き）で iPhone の動的ツールバーによる下部切れを修正
- `body` に `min-height: 100dvh` と `padding-bottom: env(safe-area-inset-bottom)` 追加
- フローティングバー（サポート選択モード）に `safe-area-inset-bottom` 対応

### 遅延チャンクのプリフェッチ
- `requestIdleCallback` でブラウザアイドル時に全遅延チャンクをバックグラウンドDL
- 初回ロードサイズを維持しつつ、モーダル表示時の遅延を解消
- `App.tsx`（5チャンク）と `AppHeader.tsx`（2チャンク）に実装

## 確認事項
- [ ] 動作確認済み
