### PR TITLE
fix(ui): モーダル高さをdvhから%に変更してsafe-area対応を修正

### DIFF
--- a/src/constant/styles.ts
+++ b/src/constant/styles.ts
@@ -76,16 +76,15 @@ export const INPUT_LOCKED = 'bg-blue-50 border-blue-200 text-blue-600 cursor-not
 export const MODAL_BACKDROP = 'absolute inset-0 bg-black/40 backdrop-blur-sm'
 
 /** モーダル白パネル（サポート詳細用） */
-export const MODAL_PANEL_DETAIL =
-  'relative bg-white rounded-2xl shadow-2xl max-w-2xl w-full h-[90vh] h-[90dvh] overflow-y-auto'
+export const MODAL_PANEL_DETAIL = 'relative bg-white rounded-2xl shadow-2xl max-w-2xl w-full h-[90%] overflow-y-auto'
 
 /** モーダル白パネル（スコア内訳用） */
 export const MODAL_PANEL_SCORE =
-  'relative bg-white rounded-2xl shadow-2xl max-w-md w-full max-h-[80vh] max-h-[80dvh] flex flex-col overflow-hidden'
+  'relative bg-white rounded-2xl shadow-2xl max-w-md w-full max-h-[80%] flex flex-col overflow-hidden'
 
 /** モーダル白パネル（フィルタ・ソート用） */
 export const MODAL_PANEL_FILTER =
-  'relative bg-white rounded-2xl shadow-2xl max-w-md w-full h-[85vh] h-[85dvh] flex flex-col overflow-hidden'
+  'relative bg-white rounded-2xl shadow-2xl max-w-md w-full h-[85%] flex flex-col overflow-hidden'
 
 /** SpinnerInput: +/- ボタン（通常時） */
 export const SPINNER_BTN = 'w-6 h-6 flex items-center justify-center rounded text-xs font-bold'


### PR DESCRIPTION
## 概要
iPhoneでモーダルの下部コンテンツがSafariツールバーに隠れる問題を修正。

## 変更内容
- モーダルパネルの高さ指定を `dvh`（ビューポート単位）から `%`（親コンテナ基準）に変更
  - `MODAL_PANEL_DETAIL`: `h-[90vh] h-[90dvh]` → `h-[90%]`
  - `MODAL_PANEL_SCORE`: `max-h-[80vh] max-h-[80dvh]` → `max-h-[80%]`
  - `MODAL_PANEL_FILTER`: `h-[85vh] h-[85dvh]` → `h-[85%]`
- `dvh` だと ModalOverlay の `safe-area-inset-*` パディングを無視してパネルがはみ出していた
- `%` にすることで、safe-area を差し引いた親コンテナの内側領域を基準にモーダルが収まるように

## 確認事項
- [ ] 動作確認済み
