### PR TITLE
perf: 遅延チャンクのプリフェッチをlink rel=prefetch方式に変更

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,23 +34,6 @@ function App() {
   const { t } = useTranslation()
   const state = useAppState()
 
-  // アイドル時に遅延チャンクをプリフェッチ（モーダル操作時の読み込み待ちを解消）
-  useEffect(() => {
-    const preload = () => {
-      import('./components/cardDetailModal/CardDetailModal')
-      import('./components/scoreDetailModal/ScoreDetailModal')
-      import('./components/scoreSettingsPanel/ScoreSettingsPanel')
-      import('./components/filterBar/FilterSortModal')
-      import('./components/unitSimulator/UnitSimulatorPanel')
-    }
-    if ('requestIdleCallback' in window) {
-      const id = requestIdleCallback(preload)
-      return () => cancelIdleCallback(id)
-    }
-    const timer = setTimeout(preload, 2000)
-    return () => clearTimeout(timer)
-  }, [])
-
   // サポート一覧選択モード: UnitSimulatorPanel が登録する addCard コールバック
   const addManualCardRef = useRef<((cardName: string) => void) | null>(null)
   const registerAddManualCard = useCallback((fn: ((cardName: string) => void) | null) => {

--- a/src/components/header/AppHeader.tsx
+++ b/src/components/header/AppHeader.tsx
@@ -6,7 +6,7 @@
  * データ管理パネル、モバイルメニューを含む。
  */
 import { useTranslation } from 'react-i18next'
-import { useState, useEffect, lazy, Suspense } from 'react'
+import { useState, lazy, Suspense } from 'react'
 import { useCardUIContext } from '../../contexts/CardContext'
 import * as constant from '../../constant'
 import { getFilterButtonStyle } from '../../data/ui'
@@ -53,20 +53,6 @@ export default function AppHeader({
   const { uncapEditMode, onToggleUncapEdit } = useCardUIContext()
   const [helpOpen, setHelpOpen] = useState(false)
   const [aboutOpen, setAboutOpen] = useState(false)
-
-  // アイドル時にモーダルチャンクをプリフェッチ
-  useEffect(() => {
-    const preload = () => {
-      import('../helpModal/HelpModal')
-      import('../aboutModal/AboutModal')
-    }
-    if ('requestIdleCallback' in window) {
-      const id = requestIdleCallback(preload)
-      return () => cancelIdleCallback(id)
-    }
-    const timer = setTimeout(preload, 2000)
-    return () => clearTimeout(timer)
-  }, [])
 
   // ヘッダーボタンのスタイル
   const activeStyle = getFilterButtonStyle(FilterButtonCategory.Active)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,27 @@ function gtagPlugin(gaId: string): Plugin {
   }
 }
 
+// 遅延チャンクをビルド時に <link rel="prefetch"> として注入するプラグイン
+function prefetchLazyChunks(basePath: string): Plugin {
+  return {
+    name: 'prefetch-lazy-chunks',
+    enforce: 'post',
+    transformIndexHtml: {
+      order: 'post',
+      handler(_html, ctx) {
+        if (!ctx.bundle) return []
+        return Object.entries(ctx.bundle)
+          .filter(([, chunk]) => chunk.type === 'chunk' && !chunk.isEntry && chunk.isDynamicEntry)
+          .map(([fileName]) => ({
+            tag: 'link',
+            attrs: { rel: 'prefetch', href: `${basePath}${fileName}` },
+            injectTo: 'head' as const,
+          }))
+      },
+    },
+  }
+}
+
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd())
@@ -41,6 +62,7 @@ export default defineConfig(({ mode }) => {
     plugins: [
       react(),
       gtagPlugin(env.VITE_GA_ID || ''),
+      prefetchLazyChunks(basePath),
       VitePWA({
         manifest: false,
         scope: basePath,


### PR DESCRIPTION
## 概要
遅延チャンクのプリフェッチを `requestIdleCallback` + `import()` から `<link rel="prefetch">` に変更。

## 変更内容
### プリフェッチ方式変更
- **Before**: `requestIdleCallback` でアイドル時に `import()` → JS解析・実行が発生しTBTが悪化（68→）
- **After**: Viteプラグイン `prefetchLazyChunks` がビルド時に `<link rel="prefetch">` をHTMLに注入
  - ダウンロードのみ（JS解析なし）→ TBTに影響しない
  - ブラウザが低優先度でバックグラウンドDL → HTTPキャッシュに保存
  - ユーザーがモーダルを開いた時にキャッシュヒット → 遅延なし

### 削除したコード
- `App.tsx`: `requestIdleCallback` による5チャンクのプリフェッチ `useEffect`
- `AppHeader.tsx`: `requestIdleCallback` による2チャンクのプリフェッチ `useEffect` + 未使用の `useEffect` import

### 追加したコード
- `vite.config.ts`: `prefetchLazyChunks` プラグイン（ビルド時に `isDynamicEntry` チャンクを検出して `<link rel="prefetch">` 生成）

## 確認事項
- [ ] 動作確認済み
