### PR TITLE
fix(perf): prefetchをload後に動的挿入してLCP悪化を修正

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,7 +31,7 @@ function gtagPlugin(gaId: string): Plugin {
   }
 }
 
-// 遅延チャンクをビルド時に <link rel="prefetch"> として注入するプラグイン
+// 遅延チャンクをページ読み込み完了後に <link rel="prefetch"> で注入するプラグイン
 function prefetchLazyChunks(basePath: string): Plugin {
   return {
     name: 'prefetch-lazy-chunks',
@@ -40,13 +40,19 @@ function prefetchLazyChunks(basePath: string): Plugin {
       order: 'post',
       handler(_html, ctx) {
         if (!ctx.bundle) return []
-        return Object.entries(ctx.bundle)
+        const urls = Object.entries(ctx.bundle)
           .filter(([, chunk]) => chunk.type === 'chunk' && !chunk.isEntry && chunk.isDynamicEntry)
-          .map(([fileName]) => ({
-            tag: 'link',
-            attrs: { rel: 'prefetch', href: `${basePath}${fileName}` },
-            injectTo: 'head' as const,
-          }))
+          .map(([fileName]) => `${basePath}${fileName}`)
+        if (urls.length === 0) return []
+        const script = [
+          'window.addEventListener("load",function(){',
+          ...urls.map(
+            (u, i) =>
+              `var l${i}=document.createElement("link");l${i}.rel="prefetch";l${i}.href="${u}";document.head.appendChild(l${i});`,
+          ),
+          '});',
+        ].join('')
+        return [{ tag: 'script', attrs: { type: 'text/javascript' }, children: script, injectTo: 'body' as const }]
       },
     },
   }


### PR DESCRIPTION
## 概要
`<link rel="prefetch">` を `<head>` の静的配置から `load` イベント後の動的挿入に変更し、LCP悪化を修正。

## 変更内容
- `prefetchLazyChunks` プラグインの出力を変更:
  - **Before**: `<head>` に `<link rel="prefetch" href="...">` を直接配置
    - ブラウザがHTML解析時に即座にprefetchリクエストを発行
    - 低速4G環境ではLCPリソースと帯域を競合（LCP 2,195→3,920ms に悪化）
  - **After**: `<body>` 末尾に `<script>` を配置し、`load` イベント後に `<link rel="prefetch">` を動的挿入
    - ページの初期ロードが完全に完了してからprefetchが始まる
    - LCP/FCP/TBTすべてに影響なし

## 確認事項
- [ ] 動作確認済み
