### PR TITLE
fix(data): activity_supply_gift_hp を点数計算から除外

### DIFF
--- a/src/data/json/cards.json
+++ b/src/data/json/cards.json
@@ -13031,7 +13031,8 @@
       {
         "name_key": "activity_supply_gift_hp",
         "trigger_key": "activity_supply_gift",
-        "values": {}
+        "values": {},
+        "skip_calculation": true
       },
       {
         "name_key": "event_boost",
@@ -16688,7 +16689,8 @@
       {
         "name_key": "activity_supply_gift_hp",
         "trigger_key": "activity_supply_gift",
-        "values": {}
+        "values": {},
+        "skip_calculation": true
       },
       {
         "name_key": "exam_end",


### PR DESCRIPTION
## 概要
「活動支給・差し入れ時体力回復」アビリティがスコア計算に誤って含まれていたため除外する。

## 変更内容
- `src/data/json/cards.json`: `activity_supply_gift_hp` の能力2件に `skip_calculation: true` を追加

## 確認事項
- [x] 動作確認済み
