### PR TITLE
fix(data): vo/da/vi_lesson_bonus の trigger_key を parameter_bonus に修正し is_parameter_bonus フラグを追加

### DIFF
--- a/src/data/json/cards.json
+++ b/src/data/json/cards.json
@@ -277,10 +277,11 @@
     "abilities": [
       {
         "name_key": "parameter_bonus",
-        "trigger_key": "da_lesson_bonus",
+        "trigger_key": "da_parameter_bonus",
         "parameter_type": "dance",
         "values": {},
-        "is_percentage": true
+        "is_percentage": true,
+        "is_parameter_bonus": true
       },
       {
         "name_key": "initial_pp",
@@ -740,10 +741,11 @@
     "abilities": [
       {
         "name_key": "parameter_bonus",
-        "trigger_key": "da_lesson_bonus",
+        "trigger_key": "da_parameter_bonus",
         "parameter_type": "dance",
         "values": {},
-        "is_percentage": true
+        "is_percentage": true,
+        "is_parameter_bonus": true
       },
       {
         "name_key": "initial_pp",
@@ -807,10 +809,11 @@
     "abilities": [
       {
         "name_key": "parameter_bonus",
-        "trigger_key": "vi_lesson_bonus",
+        "trigger_key": "vi_parameter_bonus",
         "parameter_type": "visual",
         "values": {},
-        "is_percentage": true
+        "is_percentage": true,
+        "is_parameter_bonus": true
       },
       {
         "name_key": "initial_pp",
@@ -1261,9 +1264,7 @@
           "count": 1
         }
       },
-      "actions": [
-        "delete"
-      ]
+      "actions": ["delete"]
     },
     "skill_card": null
   },
@@ -1356,9 +1357,7 @@
           "count": 1
         }
       },
-      "actions": [
-        "delete"
-      ]
+      "actions": ["delete"]
     },
     "skill_card": null
   },
@@ -1536,9 +1535,7 @@
           }
         ]
       },
-      "actions": [
-        "enhance"
-      ]
+      "actions": ["enhance"]
     },
     "skill_card": null
   },
@@ -1640,9 +1637,7 @@
         "value": 20,
         "max_count": 2
       },
-      "actions": [
-        "p_drink_acquire"
-      ]
+      "actions": ["p_drink_acquire"]
     },
     "skill_card": null
   },
@@ -1747,9 +1742,7 @@
         "value": 20,
         "max_count": 1
       },
-      "actions": [
-        "enhance"
-      ]
+      "actions": ["enhance"]
     },
     "skill_card": null
   },
@@ -1764,10 +1757,11 @@
     "abilities": [
       {
         "name_key": "parameter_bonus",
-        "trigger_key": "vi_lesson_bonus",
+        "trigger_key": "vi_parameter_bonus",
         "parameter_type": "visual",
         "values": {},
-        "is_percentage": true
+        "is_percentage": true,
+        "is_parameter_bonus": true
       },
       {
         "name_key": "lesson_pp_boost",
@@ -2337,10 +2331,7 @@
         "value": 30,
         "max_count": 1
       },
-      "actions": [
-        "delete",
-        "trouble_delete"
-      ]
+      "actions": ["delete", "trouble_delete"]
     },
     "skill_card": null
   },
@@ -2899,6 +2890,104 @@
     }
   },
   {
+    "name": "のんびり美味しいひととき",
+    "rarity": "sr",
+    "plan": "anomaly",
+    "type": "visual",
+    "parameter_type": "visual",
+    "source": "gacha",
+    "release_date": "2026/04/29",
+    "abilities": [
+      {
+        "name_key": "initial_stat",
+        "trigger_key": "vi_initial_stat",
+        "parameter_type": "visual",
+        "values": {},
+        "is_initial_stat": true
+      },
+      {
+        "name_key": "sp_lesson_rate",
+        "trigger_key": "vi_sp_lesson_rate",
+        "parameter_type": "visual",
+        "values": {},
+        "is_percentage": true,
+        "skip_calculation": true
+      },
+      {
+        "name_key": "support_rate",
+        "trigger_key": "support_rate",
+        "values": {},
+        "is_percentage": true,
+        "skip_calculation": true
+      },
+      {
+        "name_key": "sp_lesson_20",
+        "trigger_key": "sp_lesson_20",
+        "parameter_type": "visual",
+        "values": {},
+        "max_count": 4
+      },
+      {
+        "name_key": "skill_acquire",
+        "trigger_key": "skill_acquire",
+        "parameter_type": "visual",
+        "values": {}
+      },
+      {
+        "name_key": "event_boost",
+        "trigger_key": "event_boost",
+        "values": {},
+        "is_percentage": true,
+        "is_event_boost": true
+      }
+    ],
+    "events": [
+      {
+        "release": "initial",
+        "effect_type": "p_item",
+        "title": ""
+      },
+      {
+        "release": "lv20",
+        "effect_type": "param_boost",
+        "param_type": "visual",
+        "param_value": 15,
+        "title": ""
+      }
+    ],
+    "p_item": {
+      "name": "のんびりアフタヌーン",
+      "rarity": "sr",
+      "memory": "memorizable",
+      "effect": {
+        "restriction": {
+          "key": "lesson_turn",
+          "param": "visual"
+        },
+        "trigger": {
+          "key": "direct_keyword_gain",
+          "keyword": "full_power_value"
+        },
+        "condition": {
+          "key": "keyword_state",
+          "keyword": "full_power"
+        },
+        "body": [
+          {
+            "key": "keyword_up",
+            "keyword": "full_power_value",
+            "value": 6
+          }
+        ],
+        "limit": {
+          "key": "per_lesson",
+          "count": 1
+        }
+      }
+    },
+    "skill_card": null
+  },
+  {
     "name": "はじめてのお友達",
     "rarity": "sr",
     "plan": "free",
@@ -3158,9 +3247,7 @@
         "value": 20,
         "max_count": 2
       },
-      "actions": [
-        "p_drink_acquire"
-      ]
+      "actions": ["p_drink_acquire"]
     },
     "skill_card": null
   },
@@ -3254,9 +3341,7 @@
           "count": 1
         }
       },
-      "actions": [
-        "enhance"
-      ]
+      "actions": ["enhance"]
     },
     "skill_card": null
   },
@@ -3442,9 +3527,7 @@
           }
         ]
       },
-      "actions": [
-        "p_drink_acquire"
-      ]
+      "actions": ["p_drink_acquire"]
     },
     "skill_card": null
   },
@@ -4014,9 +4097,7 @@
           "count": 2
         }
       },
-      "actions": [
-        "p_drink_acquire"
-      ]
+      "actions": ["p_drink_acquire"]
     },
     "skill_card": null
   },
@@ -4404,9 +4485,7 @@
           "count": 1
         }
       },
-      "actions": [
-        "enhance"
-      ]
+      "actions": ["enhance"]
     },
     "skill_card": null
   },
@@ -4699,9 +4778,7 @@
           "count": 1
         }
       },
-      "actions": [
-        "enhance"
-      ]
+      "actions": ["enhance"]
     },
     "skill_card": null
   },
@@ -4792,9 +4869,7 @@
           "count": 2
         }
       },
-      "actions": [
-        "enhance"
-      ]
+      "actions": ["enhance"]
     },
     "skill_card": null
   },
@@ -4887,9 +4962,7 @@
           "count": 1
         }
       },
-      "actions": [
-        "delete"
-      ]
+      "actions": ["delete"]
     },
     "skill_card": null
   },
@@ -4904,10 +4977,11 @@
     "abilities": [
       {
         "name_key": "parameter_bonus",
-        "trigger_key": "vi_lesson_bonus",
+        "trigger_key": "vi_parameter_bonus",
         "parameter_type": "visual",
         "values": {},
-        "is_percentage": true
+        "is_percentage": true,
+        "is_parameter_bonus": true
       },
       {
         "name_key": "initial_pp",
@@ -5187,10 +5261,7 @@
           "count": 1
         }
       },
-      "actions": [
-        "delete",
-        "trouble_delete"
-      ]
+      "actions": ["delete", "trouble_delete"]
     },
     "skill_card": null
   },
@@ -5205,10 +5276,11 @@
     "abilities": [
       {
         "name_key": "parameter_bonus",
-        "trigger_key": "da_lesson_bonus",
+        "trigger_key": "da_parameter_bonus",
         "parameter_type": "dance",
         "values": {},
-        "is_percentage": true
+        "is_percentage": true,
+        "is_parameter_bonus": true
       },
       {
         "name_key": "initial_pp",
@@ -5387,10 +5459,7 @@
         "value": 30,
         "max_count": 1
       },
-      "actions": [
-        "delete",
-        "trouble_delete"
-      ]
+      "actions": ["delete", "trouble_delete"]
     },
     "skill_card": null
   },
@@ -5881,9 +5950,7 @@
           "count": 2
         }
       },
-      "actions": [
-        "change"
-      ]
+      "actions": ["change"]
     },
     "skill_card": null
   },
@@ -6765,9 +6832,7 @@
           "count": 2
         }
       },
-      "actions": [
-        "enhance"
-      ]
+      "actions": ["enhance"]
     },
     "skill_card": null
   },
@@ -6858,9 +6923,7 @@
           }
         ]
       },
-      "actions": [
-        "enhance"
-      ]
+      "actions": ["enhance"]
     },
     "skill_card": null
   },
@@ -7573,9 +7636,7 @@
           "count": 2
         }
       },
-      "actions": [
-        "p_drink_acquire"
-      ]
+      "actions": ["p_drink_acquire"]
     },
     "skill_card": null
   },
@@ -7941,9 +8002,7 @@
           "count": 2
         }
       },
-      "actions": [
-        "enhance"
-      ]
+      "actions": ["enhance"]
     },
     "skill_card": null
   },
@@ -8321,10 +8380,7 @@
           "count": 1
         }
       },
-      "actions": [
-        "delete",
-        "trouble_delete"
-      ]
+      "actions": ["delete", "trouble_delete"]
     },
     "skill_card": null
   },
@@ -8502,9 +8558,7 @@
           "count": 2
         }
       },
-      "actions": [
-        "p_drink_acquire"
-      ]
+      "actions": ["p_drink_acquire"]
     },
     "skill_card": null
   },
@@ -8614,10 +8668,11 @@
     "abilities": [
       {
         "name_key": "parameter_bonus",
-        "trigger_key": "vo_lesson_bonus",
+        "trigger_key": "vo_parameter_bonus",
         "parameter_type": "vocal",
         "values": {},
-        "is_percentage": true
+        "is_percentage": true,
+        "is_parameter_bonus": true
       },
       {
         "name_key": "initial_pp",
@@ -8788,10 +8843,7 @@
         "value": 30,
         "max_count": 1
       },
-      "actions": [
-        "delete",
-        "trouble_delete"
-      ]
+      "actions": ["delete", "trouble_delete"]
     },
     "skill_card": null
   },
@@ -10210,9 +10262,7 @@
           "count": 4
         }
       },
-      "actions": [
-        "p_drink_acquire"
-      ]
+      "actions": ["p_drink_acquire"]
     },
     "skill_card": null
   },
@@ -10310,11 +10360,123 @@
           "count": 2
         }
       },
-      "actions": [
-        "enhance"
-      ]
+      "actions": ["enhance"]
     },
     "skill_card": null
+  },
+  {
+    "name": "あなたとふたり、電車で",
+    "rarity": "ssr",
+    "plan": "anomaly",
+    "type": "vocal",
+    "parameter_type": "vocal",
+    "source": "gacha",
+    "release_date": "2026/04/29",
+    "abilities": [
+      {
+        "name_key": "initial_stat",
+        "trigger_key": "vo_initial_stat",
+        "parameter_type": "vocal",
+        "values": {},
+        "is_initial_stat": true
+      },
+      {
+        "name_key": "sp_lesson_rate",
+        "trigger_key": "vo_sp_lesson_rate",
+        "parameter_type": "vocal",
+        "values": {},
+        "is_percentage": true,
+        "skip_calculation": true
+      },
+      {
+        "name_key": "support_rate",
+        "trigger_key": "support_rate",
+        "values": {},
+        "is_percentage": true,
+        "skip_calculation": true
+      },
+      {
+        "name_key": "sp_lesson_20",
+        "trigger_key": "sp_lesson_20",
+        "parameter_type": "vocal",
+        "values": {},
+        "max_count": 4
+      },
+      {
+        "name_key": "ssr_card_acquire",
+        "trigger_key": "ssr_card_acquire",
+        "parameter_type": "vocal",
+        "values": {}
+      },
+      {
+        "name_key": "event_boost",
+        "trigger_key": "event_boost",
+        "values": {},
+        "is_percentage": true,
+        "is_event_boost": true
+      }
+    ],
+    "events": [
+      {
+        "release": "initial",
+        "effect_type": "skill_card",
+        "title": ""
+      },
+      {
+        "release": "lv20",
+        "effect_type": "param_boost",
+        "param_type": "vocal",
+        "param_value": 20,
+        "title": ""
+      },
+      {
+        "release": "lv40",
+        "effect_type": "card_enhance",
+        "title": ""
+      }
+    ],
+    "p_item": null,
+    "skill_card": {
+      "name": "ガタゴトすやすや",
+      "rarity": "ssr",
+      "type": "active",
+      "lesson_limit": 1,
+      "no_duplicate": true,
+      "effects": [
+        {
+          "level": "base",
+          "cost_type": "vitality",
+          "cost_value": 1,
+          "effect": {
+            "use_condition": {
+              "key": "keyword_state",
+              "keyword": "reserve"
+            },
+            "groups": [
+              {
+                "action": {
+                  "key": "change_policy",
+                  "keyword": "aggressive"
+                }
+              },
+              {
+                "action": {
+                  "key": "param_up",
+                  "value": 11
+                }
+              },
+              {
+                "action": {
+                  "key": "replace_all_hand"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "custom_cap": 1,
+      "custom_slot": []
+    }
   },
   {
     "name": "あなたにも作ってあげる！",
@@ -11212,10 +11374,11 @@
     "abilities": [
       {
         "name_key": "parameter_bonus",
-        "trigger_key": "vi_lesson_bonus",
+        "trigger_key": "vi_parameter_bonus",
         "parameter_type": "visual",
         "values": {},
-        "is_percentage": true
+        "is_percentage": true,
+        "is_parameter_bonus": true
       },
       {
         "name_key": "sp_lesson_pp",
@@ -11411,10 +11574,11 @@
     "abilities": [
       {
         "name_key": "parameter_bonus",
-        "trigger_key": "vi_lesson_bonus",
+        "trigger_key": "vi_parameter_bonus",
         "parameter_type": "visual",
         "values": {},
-        "is_percentage": true
+        "is_percentage": true,
+        "is_parameter_bonus": true
       },
       {
         "name_key": "initial_pp",
@@ -12983,9 +13147,7 @@
           "count": 1
         }
       },
-      "actions": [
-        "enhance"
-      ]
+      "actions": ["enhance"]
     },
     "skill_card": null
   },
@@ -13832,9 +13994,7 @@
         "value": 30,
         "max_count": 2
       },
-      "actions": [
-        "p_drink_acquire"
-      ]
+      "actions": ["p_drink_acquire"]
     },
     "skill_card": null
   },
@@ -13849,10 +14009,11 @@
     "abilities": [
       {
         "name_key": "parameter_bonus",
-        "trigger_key": "vo_lesson_bonus",
+        "trigger_key": "vo_parameter_bonus",
         "parameter_type": "vocal",
         "values": {},
-        "is_percentage": true
+        "is_percentage": true,
+        "is_parameter_bonus": true
       },
       {
         "name_key": "sp_lesson_rate",
@@ -13933,9 +14094,7 @@
           "count": 2
         }
       },
-      "actions": [
-        "enhance"
-      ]
+      "actions": ["enhance"]
     },
     "skill_card": null
   },
@@ -14033,9 +14192,7 @@
           "count": 2
         }
       },
-      "actions": [
-        "delete"
-      ]
+      "actions": ["delete"]
     },
     "skill_card": null
   },
@@ -14404,10 +14561,11 @@
     "abilities": [
       {
         "name_key": "parameter_bonus",
-        "trigger_key": "vo_lesson_bonus",
+        "trigger_key": "vo_parameter_bonus",
         "parameter_type": "vocal",
         "values": {},
-        "is_percentage": true
+        "is_percentage": true,
+        "is_parameter_bonus": true
       },
       {
         "name_key": "sp_lesson_hp",
@@ -14499,10 +14657,11 @@
     "abilities": [
       {
         "name_key": "parameter_bonus",
-        "trigger_key": "vo_lesson_bonus",
+        "trigger_key": "vo_parameter_bonus",
         "parameter_type": "vocal",
         "values": {},
-        "is_percentage": true
+        "is_percentage": true,
+        "is_parameter_bonus": true
       },
       {
         "name_key": "initial_pp",
@@ -17888,10 +18047,11 @@
     "abilities": [
       {
         "name_key": "parameter_bonus",
-        "trigger_key": "vi_lesson_bonus",
+        "trigger_key": "vi_parameter_bonus",
         "parameter_type": "visual",
         "values": {},
-        "is_percentage": true
+        "is_percentage": true,
+        "is_parameter_bonus": true
       },
       {
         "name_key": "initial_pp",
@@ -17969,9 +18129,7 @@
           "count": 4
         }
       },
-      "actions": [
-        "p_drink_acquire"
-      ]
+      "actions": ["p_drink_acquire"]
     },
     "skill_card": null
   },
@@ -17986,10 +18144,11 @@
     "abilities": [
       {
         "name_key": "parameter_bonus",
-        "trigger_key": "da_lesson_bonus",
+        "trigger_key": "da_parameter_bonus",
         "parameter_type": "dance",
         "values": {},
-        "is_percentage": true
+        "is_percentage": true,
+        "is_parameter_bonus": true
       },
       {
         "name_key": "initial_pp",
@@ -18272,9 +18431,7 @@
         "value": 10,
         "max_count": 2
       },
-      "actions": [
-        "change"
-      ]
+      "actions": ["change"]
     },
     "skill_card": null
   },
@@ -18762,10 +18919,11 @@
     "abilities": [
       {
         "name_key": "parameter_bonus",
-        "trigger_key": "vo_lesson_bonus",
+        "trigger_key": "vo_parameter_bonus",
         "parameter_type": "vocal",
         "values": {},
-        "is_percentage": true
+        "is_percentage": true,
+        "is_parameter_bonus": true
       },
       {
         "name_key": "initial_pp",
@@ -19705,9 +19863,7 @@
           "count": 2
         }
       },
-      "actions": [
-        "enhance"
-      ]
+      "actions": ["enhance"]
     },
     "skill_card": null
   },
@@ -19999,9 +20155,7 @@
         "parameter_type": "visual",
         "value": 15
       },
-      "actions": [
-        "change"
-      ]
+      "actions": ["change"]
     },
     "skill_card": null
   },
@@ -20016,10 +20170,11 @@
     "abilities": [
       {
         "name_key": "parameter_bonus",
-        "trigger_key": "da_lesson_bonus",
+        "trigger_key": "da_parameter_bonus",
         "parameter_type": "dance",
         "values": {},
-        "is_percentage": true
+        "is_percentage": true,
+        "is_parameter_bonus": true
       },
       {
         "name_key": "sp_lesson_hp",
@@ -20312,10 +20467,11 @@
     "abilities": [
       {
         "name_key": "parameter_bonus",
-        "trigger_key": "vo_lesson_bonus",
+        "trigger_key": "vo_parameter_bonus",
         "parameter_type": "vocal",
         "values": {},
-        "is_percentage": true
+        "is_percentage": true,
+        "is_parameter_bonus": true
       },
       {
         "name_key": "initial_pp",
@@ -21343,10 +21499,11 @@
     "abilities": [
       {
         "name_key": "parameter_bonus",
-        "trigger_key": "vi_lesson_bonus",
+        "trigger_key": "vi_parameter_bonus",
         "parameter_type": "visual",
         "values": {},
-        "is_percentage": true
+        "is_percentage": true,
+        "is_parameter_bonus": true
       },
       {
         "name_key": "a_skill_acquire",
@@ -22072,218 +22229,6 @@
         "limit": {
           "key": "per_lesson",
           "count": 2
-        }
-      }
-    },
-    "skill_card": null
-  },
-  {
-    "name": "あなたとふたり、電車で",
-    "rarity": "ssr",
-    "plan": "anomaly",
-    "type": "vocal",
-    "parameter_type": "vocal",
-    "source": "gacha",
-    "release_date": "2026/04/29",
-    "abilities": [
-      {
-        "name_key": "initial_stat",
-        "trigger_key": "vo_initial_stat",
-        "parameter_type": "vocal",
-        "values": {},
-        "is_initial_stat": true
-      },
-      {
-        "name_key": "sp_lesson_rate",
-        "trigger_key": "vo_sp_lesson_rate",
-        "parameter_type": "vocal",
-        "values": {},
-        "is_percentage": true,
-        "skip_calculation": true
-      },
-      {
-        "name_key": "support_rate",
-        "trigger_key": "support_rate",
-        "values": {},
-        "is_percentage": true,
-        "skip_calculation": true
-      },
-      {
-        "name_key": "sp_lesson_20",
-        "trigger_key": "sp_lesson_20",
-        "parameter_type": "vocal",
-        "values": {},
-        "max_count": 4
-      },
-      {
-        "name_key": "ssr_card_acquire",
-        "trigger_key": "ssr_card_acquire",
-        "parameter_type": "vocal",
-        "values": {}
-      },
-      {
-        "name_key": "event_boost",
-        "trigger_key": "event_boost",
-        "values": {},
-        "is_percentage": true,
-        "is_event_boost": true
-      }
-    ],
-    "events": [
-      {
-        "release": "initial",
-        "effect_type": "skill_card",
-        "title": ""
-      },
-      {
-        "release": "lv20",
-        "effect_type": "param_boost",
-        "param_type": "vocal",
-        "param_value": 20,
-        "title": ""
-      },
-      {
-        "release": "lv40",
-        "effect_type": "card_enhance",
-        "title": ""
-      }
-    ],
-    "p_item": null,
-    "skill_card": {
-      "name": "ガタゴトすやすや",
-      "rarity": "ssr",
-      "type": "active",
-      "lesson_limit": 1,
-      "no_duplicate": true,
-      "effects": [
-        {
-          "level": "base",
-          "cost_type": "vitality",
-          "cost_value": 1,
-          "effect": {
-            "use_condition": {
-              "key": "keyword_state",
-              "keyword": "reserve"
-            },
-            "groups": [
-              {
-                "action": {
-                  "key": "change_policy",
-                  "keyword": "aggressive"
-                }
-              },
-              {
-                "action": {
-                  "key": "param_up",
-                  "value": 11
-                }
-              },
-              {
-                "action": {
-                  "key": "replace_all_hand"
-                }
-              }
-            ]
-          }
-        }
-      ],
-      "custom_cap": 1,
-      "custom_slot": []
-    }
-  },
-  {
-    "name": "のんびり美味しいひととき",
-    "rarity": "sr",
-    "plan": "anomaly",
-    "type": "visual",
-    "parameter_type": "visual",
-    "source": "gacha",
-    "release_date": "2026/04/29",
-    "abilities": [
-      {
-        "name_key": "initial_stat",
-        "trigger_key": "vi_initial_stat",
-        "parameter_type": "visual",
-        "values": {},
-        "is_initial_stat": true
-      },
-      {
-        "name_key": "sp_lesson_rate",
-        "trigger_key": "vi_sp_lesson_rate",
-        "parameter_type": "visual",
-        "values": {},
-        "is_percentage": true,
-        "skip_calculation": true
-      },
-      {
-        "name_key": "support_rate",
-        "trigger_key": "support_rate",
-        "values": {},
-        "is_percentage": true,
-        "skip_calculation": true
-      },
-      {
-        "name_key": "sp_lesson_20",
-        "trigger_key": "sp_lesson_20",
-        "parameter_type": "visual",
-        "values": {},
-        "max_count": 4
-      },
-      {
-        "name_key": "skill_acquire",
-        "trigger_key": "skill_acquire",
-        "parameter_type": "visual",
-        "values": {}
-      },
-      {
-        "name_key": "event_boost",
-        "trigger_key": "event_boost",
-        "values": {},
-        "is_percentage": true,
-        "is_event_boost": true
-      }
-    ],
-    "events": [
-      {
-        "release": "initial",
-        "effect_type": "p_item",
-        "title": ""
-      },
-      {
-        "release": "lv20",
-        "effect_type": "param_boost",
-        "param_type": "visual",
-        "param_value": 15,
-        "title": ""
-      }
-    ],
-    "p_item": {
-      "name": "のんびりアフタヌーン",
-      "rarity": "sr",
-      "memory": "memorizable",
-      "effect": {
-        "restriction": {
-          "key": "lesson_turn",
-          "param": "visual"
-        },
-        "trigger": {
-          "key": "direct_keyword_gain",
-          "keyword": "full_power_value"
-        },
-        "condition": {
-          "key": "keyword_state",
-          "keyword": "full_power"
-        },
-        "body": [
-          {
-            "key": "keyword_up",
-            "keyword": "full_power_value",
-            "value": 6
-          }
-        ],
-        "limit": {
-          "key": "per_lesson",
-          "count": 1
         }
       }
     },


### PR DESCRIPTION
## 概要

`vo/da/vi_lesson_bonus` という trigger_key を持つアビリティが `is_parameter_bonus: true` フラグを欠いていたため、スコア計算の `getParamBonusPercent` にピックアップされずパラメータボーナスが計算されないバグを修正。

## 変更内容

- `src/data/json/cards.json`: 18枚のカードの `vo/da/vi_lesson_bonus` → `vo/da/vi_parameter_bonus` に修正、`is_parameter_bonus: true` を追加

## 確認事項
- [x] 動作確認済み
- [x] 全テスト通過（1580件）
