### PR TITLE
fix(unit): レンタル枠固定・タイプ制約・未所持カード選択のバグ修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@
  * 組み合わせて表示する。useAppState で全体の状態を管理する。
  */
 import { useTranslation } from 'react-i18next'
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from 'react'
 
 import AppHeader from './components/header/AppHeader'
 import CardList from './components/cardList/CardList'
@@ -43,8 +43,11 @@ function App() {
 
   // サポート一覧選択モード: サポート選択可否判定関数
   const isCardEligibleRef = useRef<((card: SupportCard) => boolean) | null>(null)
+  // isCardEligible の更新を CardListItem に伝えるためのバージョンカウンター
+  const [eligibilityVersion, setEligibilityVersion] = useState(0)
   const registerIsCardEligible = useCallback((fn: ((card: SupportCard) => boolean) | null) => {
     isCardEligibleRef.current = fn
+    if (fn !== null) setEligibilityVersion((v) => v + 1)
   }, [])
 
   // unitCardSelectMode を ref で保持して onCardClick / isCardEligible を安定化する
@@ -66,6 +69,15 @@ function App() {
       handleCardClick(card)
     },
     [handleCardClick],
+  )
+
+  // 選択モード中はスコアモーダルを開かない（ref で安定化）
+  const onScoreClick = useCallback(
+    (card: SupportCard, e: MouseEvent) => {
+      if (unitCardSelectModeRef.current) return
+      handleScoreClick(card, e)
+    },
+    [handleScoreClick],
   )
 
   // サポート選択可否判定（ref で安定化）
@@ -94,19 +106,12 @@ function App() {
     () => ({
       getCardUncap: state.scores.getCardUncap,
       onCardClick,
-      onScoreClick: handleScoreClick,
+      onScoreClick,
       onUncapChange: handleUncapChange,
       onEditUserCard: handleEditUserCard,
       onDeleteUserCard: handleDeleteUserCard,
     }),
-    [
-      state.scores.getCardUncap,
-      onCardClick,
-      handleScoreClick,
-      handleUncapChange,
-      handleEditUserCard,
-      handleDeleteUserCard,
-    ],
+    [state.scores.getCardUncap, onCardClick, onScoreClick, handleUncapChange, handleEditUserCard, handleDeleteUserCard],
   )
 
   // CardUIContext: 変化する UI 状態（編集モード・選択モード切替時のみ再生成）
@@ -116,8 +121,9 @@ function App() {
       onToggleUncapEdit: handleToggleUncapEdit,
       unitCardSelectMode: state.ui.unitCardSelectMode,
       isCardEligible,
+      eligibilityVersion,
     }),
-    [state.ui.uncapEditMode, handleToggleUncapEdit, state.ui.unitCardSelectMode, isCardEligible],
+    [state.ui.uncapEditMode, handleToggleUncapEdit, state.ui.unitCardSelectMode, isCardEligible, eligibilityVersion],
   )
 
   // パネル表示に応じてモーダルの右オフセットクラスを計算する
@@ -286,6 +292,7 @@ function App() {
                 scoreSettings={state.scores.scoreSettings}
                 allCards={state.userCards.allCards}
                 allCardByName={state.userCards.allCardByName}
+                cardUncaps={state.scores.cardUncaps}
               />
             </Suspense>
           )}

--- a/src/__tests__/utils/unitSimulator.test.ts
+++ b/src/__tests__/utils/unitSimulator.test.ts
@@ -1395,4 +1395,168 @@ describe('最適編成', () => {
       })
     }
   })
+
+  describe('タイプ枚数制約の遵守', () => {
+    it('Voロック3枚 + typeCountMax.Vocal=3 のとき最適化結果のVo枚数が3以下になる', () => {
+      const scoreSettings = makeScoreSettings()
+      const voCards = AllCards.filter(
+        (c) =>
+          (c.plan === enums.PlanType.Anomaly || c.plan === enums.PlanType.Free) && c.type === enums.ParameterType.Vocal,
+      )
+      if (voCards.length < 3) return
+
+      const lockedVoNames = voCards.slice(0, 3).map((c) => c.name)
+      const settings = makeSimulatorSettings([], {
+        lockedCards: lockedVoNames,
+        typeCountMax: {
+          [enums.ParameterType.Vocal]: 3,
+          [enums.ParameterType.Dance]: constant.TYPE_COUNT_MAX_DEFAULT,
+          [enums.ParameterType.Visual]: constant.TYPE_COUNT_MAX_DEFAULT,
+        },
+      })
+      const result = optimizeUnit({
+        settings,
+        scoreSettings,
+        cardUncaps: {},
+        allCards: AllCards,
+        cardByName: CardByName,
+      })
+      if (!result) return
+
+      const voCount = result.members.filter((m) => m.card.type === enums.ParameterType.Vocal).length
+      expect(voCount).toBeLessThanOrEqual(3)
+    })
+
+    it('manualRental=true + Vo レンタル指定 + Voロック3枚 + typeCountMax.Vocal=3 のとき固定・レンタルが優先されVo枚数が4になる', () => {
+      const scoreSettings = makeScoreSettings()
+      const voCards = AllCards.filter(
+        (c) =>
+          (c.plan === enums.PlanType.Anomaly || c.plan === enums.PlanType.Free) && c.type === enums.ParameterType.Vocal,
+      )
+      if (voCards.length < 4) return
+
+      const lockedVoNames = voCards.slice(0, 3).map((c) => c.name)
+      const rentalVoName = voCards[3].name
+
+      // manualRental=true で Vo をレンタルに指定しつつ Vo を3枚ロック
+      // レンタルを固定しているため rentalCardName の Vo がそのまま編成に含まれ、固定3枚と合わせて Vo=4 になる
+      const settings = makeSimulatorSettings([], {
+        manualRental: true,
+        rentalCardName: rentalVoName,
+        lockedCards: lockedVoNames,
+        typeCountMax: {
+          [enums.ParameterType.Vocal]: 3,
+          [enums.ParameterType.Dance]: constant.TYPE_COUNT_MAX_DEFAULT,
+          [enums.ParameterType.Visual]: constant.TYPE_COUNT_MAX_DEFAULT,
+        },
+      })
+      const result = optimizeUnit({
+        settings,
+        scoreSettings,
+        cardUncaps: {},
+        allCards: AllCards,
+        cardByName: CardByName,
+      })
+      if (!result) return
+
+      // 固定3枚 + レンタル1枚 = Vo4枚（typeCountMax を超えるが意図的に許容）
+      const voCount = result.members.filter((m) => m.card.type === enums.ParameterType.Vocal).length
+      expect(voCount).toBe(4)
+      // 固定カードがすべて含まれること
+      const resultNames = result.members.map((m) => m.card.name)
+      for (const name of lockedVoNames) {
+        expect(resultNames).toContain(name)
+      }
+      // レンタルカードが含まれること
+      expect(resultNames).toContain(rentalVoName)
+    })
+
+    it('manualRental=true + Vo レンタル指定 + Voロック3枚 + typeCountMax.Vocal=3: 実際のユニット構成を検証', () => {
+      // このテストは実際の関数呼び出し結果をログ出力して動作確認する
+      const scoreSettings = makeScoreSettings()
+      const voCards = AllCards.filter(
+        (c) =>
+          (c.plan === enums.PlanType.Anomaly || c.plan === enums.PlanType.Free) && c.type === enums.ParameterType.Vocal,
+      )
+      // Vo カードが4枚以上あることを確認（なければ失敗させてテストデータ不足を検知）
+      expect(voCards.length).toBeGreaterThanOrEqual(4)
+
+      const lockedVoNames = voCards.slice(0, 3).map((c) => c.name)
+      const rentalVoName = voCards[3].name
+
+      const settings = makeSimulatorSettings([], {
+        manualRental: true,
+        rentalCardName: rentalVoName,
+        lockedCards: lockedVoNames,
+        typeCountMax: {
+          [enums.ParameterType.Vocal]: 3,
+          [enums.ParameterType.Dance]: constant.TYPE_COUNT_MAX_DEFAULT,
+          [enums.ParameterType.Visual]: constant.TYPE_COUNT_MAX_DEFAULT,
+        },
+      })
+      const result = optimizeUnit({
+        settings,
+        scoreSettings,
+        cardUncaps: {},
+        allCards: AllCards,
+        cardByName: CardByName,
+      })
+
+      expect(result).not.toBeNull()
+      // 3固定 + 1レンタル = Vo4枚
+      const voCount = result!.members.filter((m) => m.card.type === enums.ParameterType.Vocal).length
+      expect(voCount).toBe(4)
+      const resultNames = result!.members.map((m) => m.card.name)
+      // 固定3枚が全て含まれること
+      for (const name of lockedVoNames) {
+        expect(resultNames).toContain(name)
+      }
+      // レンタルカードが含まれること
+      expect(resultNames).toContain(rentalVoName)
+      // レンタルバッジが付いていること
+      const rentalMember = result!.members.find((m) => m.card.name === rentalVoName)
+      expect(rentalMember?.isRental).toBe(true)
+    })
+
+    it('manualRental=false + Voロック4枚 + typeCountMax.Vocal=3 のとき自動レンタルはVoを選出しない', () => {
+      // Voが固定カードで原則上限(3)を超えている場合、自動レンタルはVoを選ばないこと
+      const scoreSettings = makeScoreSettings()
+      const voCards = AllCards.filter(
+        (c) =>
+          (c.plan === enums.PlanType.Anomaly || c.plan === enums.PlanType.Free) && c.type === enums.ParameterType.Vocal,
+      )
+      expect(voCards.length).toBeGreaterThanOrEqual(4)
+
+      const lockedVoNames = voCards.slice(0, 4).map((c) => c.name)
+
+      const settings = makeSimulatorSettings([], {
+        manualRental: false,
+        rentalCardName: null,
+        lockedCards: lockedVoNames,
+        typeCountMax: {
+          [enums.ParameterType.Vocal]: 3,
+          [enums.ParameterType.Dance]: constant.TYPE_COUNT_MAX_DEFAULT,
+          [enums.ParameterType.Visual]: constant.TYPE_COUNT_MAX_DEFAULT,
+        },
+      })
+      const result = optimizeUnit({
+        settings,
+        scoreSettings,
+        cardUncaps: {},
+        allCards: AllCards,
+        cardByName: CardByName,
+      })
+
+      const rentalMember = result?.members.find((m) => m.isRental)
+
+      expect(result).not.toBeNull()
+      // 固定4枚Voが含まれること
+      const resultNames = result!.members.map((m) => m.card.name)
+      for (const name of lockedVoNames) {
+        expect(resultNames).toContain(name)
+      }
+      // 自動レンタルは Vo を選出しないこと
+      expect(rentalMember?.card.type).not.toBe(enums.ParameterType.Vocal)
+    })
+  })
 })

--- a/src/components/unitSimulator/UnitSimulatorPanel.tsx
+++ b/src/components/unitSimulator/UnitSimulatorPanel.tsx
@@ -144,12 +144,14 @@ export default function UnitSimulatorPanel({
       while (padded.length < constant.UNIT_SIZE) padded.push(null)
       const effectiveTargetIdx = targetSlotIndexRef.current !== null ? targetSlotIndexRef.current : padded.indexOf(null)
       const isRentalSlot = effectiveTargetIdx === constant.UNIT_SIZE - 1
-      if (!isRentalSlot && cardUncapsRef.current[card.name] === UncapType.NotOwned) return false
+      // 4凸固定モード（useFixedUncap）のときは未所持チェックをスキップする
+      if (!isRentalSlot && !scoreSettings.useFixedUncap && cardUncapsRef.current[card.name] === UncapType.NotOwned)
+        return false
       return true
     }
     registerIsCardEligible(isEligible)
     return () => registerIsCardEligible(null)
-  }, [registerIsCardEligible, settings.plan, settings.manualCards])
+  }, [registerIsCardEligible, settings.plan, settings.manualCards, scoreSettings.useFixedUncap])
 
   // 点数詳細の発動回数回数調整変更時にスコアのみ自動再計算する
   // （最適化をやり直さず、現在のユニット構成のまま計算し直す）

--- a/src/components/unitSimulator/UnitSimulatorPanel.tsx
+++ b/src/components/unitSimulator/UnitSimulatorPanel.tsx
@@ -16,7 +16,7 @@ import UnitSlotEditor from './UnitSlotEditor'
 import { useUnitSimulator } from '../../hooks/useUnitSimulator'
 import type { CardCountCustomState } from '../../hooks/useCardCountCustom'
 import { useAccordionState } from '../../hooks'
-import { ButtonSizeType, CollapsibleVariantType, PlanType, SimulatorSectionKey } from '../../types/enums'
+import { ButtonSizeType, CollapsibleVariantType, PlanType, SimulatorSectionKey, UncapType } from '../../types/enums'
 import type { SupportCard, ScoreSettings } from '../../types/card'
 import * as constant from '../../constant'
 
@@ -46,6 +46,8 @@ interface UnitSimulatorPanelProps {
   allCards: SupportCard[]
   /** サポート名→サポートのマップ（ユーザー追加カード含む） */
   allCardByName: Map<string, SupportCard>
+  /** サポート凸数マップ（未所持判定に使用） */
+  cardUncaps: Record<string, UncapType>
 }
 
 /**
@@ -66,6 +68,7 @@ export default function UnitSimulatorPanel({
   scoreSettings,
   allCards,
   allCardByName,
+  cardUncaps,
 }: UnitSimulatorPanelProps) {
   const { t } = useTranslation()
   const {
@@ -111,14 +114,22 @@ export default function UnitSimulatorPanel({
         if (emptyIdx >= 0) padded[emptyIdx] = cardName
       }
       targetSlotIndexRef.current = null
-      setSettingsRef.current({ ...s, manualCards: padded })
+      // 末尾スロットが変わったら rentalCardName を更新する（manualRental に関わらず）
+      const newRentalName = padded[constant.UNIT_SIZE - 1] !== null ? padded[constant.UNIT_SIZE - 1] : s.rentalCardName
+      setSettingsRef.current({ ...s, manualCards: padded, rentalCardName: newRentalName })
       if (padded.filter((n) => n !== null).length >= constant.UNIT_SIZE) setUnitCardSelectMode(false)
     }
     registerAddManualCard(addCard)
     return () => registerAddManualCard(null)
   }, [registerAddManualCard, setUnitCardSelectMode])
 
-  // サポート選択可否判定関数を親に登録する（プラン・重複チェック）
+  // cardUncaps を ref で保持して isEligible から参照できるようにする
+  const cardUncapsRef = useRef(cardUncaps)
+  useEffect(() => {
+    cardUncapsRef.current = cardUncaps
+  }, [cardUncaps])
+
+  // サポート選択可否判定関数を親に登録する（プラン・重複チェック・未所持チェック）
   // allowedTypes は最適化専用フィルタのため、手動編成では適用しない
   useEffect(() => {
     const isEligible = (card: SupportCard) => {
@@ -127,6 +138,14 @@ export default function UnitSimulatorPanel({
       if (card.plan !== PlanType.Free && card.plan !== s.plan) return false
       // 既に選択済みのサポートは選択不可
       if (s.manualCards.includes(card.name)) return false
+      // レンタル枠以外では未所持サポートは選択不可
+      // targetSlotIndexRef が null（連続選択中など）の場合は次に埋まる枠を計算する
+      const padded = [...s.manualCards]
+      while (padded.length < constant.UNIT_SIZE) padded.push(null)
+      const effectiveTargetIdx =
+        targetSlotIndexRef.current !== null ? targetSlotIndexRef.current : padded.indexOf(null)
+      const isRentalSlot = effectiveTargetIdx === constant.UNIT_SIZE - 1
+      if (!isRentalSlot && cardUncapsRef.current[card.name] === UncapType.NotOwned) return false
       return true
     }
     registerIsCardEligible(isEligible)
@@ -202,6 +221,18 @@ export default function UnitSimulatorPanel({
   /** サポート固定トグル */
   const handleToggleLock = useCallback(
     (cardName: string) => {
+      // レンタルカード判定: 末尾スロット（インデックス5）のカードをレンタル枠とする
+      const isRentalCard = settings.manualCards[constant.UNIT_SIZE - 1] === cardName
+      if (isRentalCard) {
+        const nowRentalLocked = settings.manualRental && settings.rentalCardName === cardName
+        if (nowRentalLocked) {
+          setSettings({ ...settings, manualRental: false, rentalCardName: null })
+        } else {
+          setSettings({ ...settings, manualRental: true, rentalCardName: cardName })
+        }
+        return
+      }
+      // 通常カードの固定アイコン: lockedCards をトグルする
       const locked = settings.lockedCards
       const next = locked.includes(cardName) ? locked.filter((n) => n !== cardName) : [...locked, cardName]
       setSettings({ ...settings, lockedCards: next })
@@ -214,8 +245,15 @@ export default function UnitSimulatorPanel({
     (name: string) => {
       const nextCards = settings.manualCards.map((n) => (n === name ? null : n))
       const nextLocked = settings.lockedCards.filter((n) => n !== name)
-      // レンタルは末尾スロット（6枠目）で位置ベースに決まるため rentalCardName のクリアは不要
-      setSettings({ ...settings, manualCards: nextCards, lockedCards: nextLocked })
+      // 末尾スロットのカードを削除したとき rentalCardName とロック状態をクリアする
+      const isRentalSlot = settings.manualCards[constant.UNIT_SIZE - 1] === name
+      setSettings({
+        ...settings,
+        manualCards: nextCards,
+        lockedCards: nextLocked,
+        manualRental: isRentalSlot ? false : settings.manualRental,
+        rentalCardName: isRentalSlot ? null : settings.rentalCardName,
+      })
     },
     [settings, setSettings],
   )
@@ -303,7 +341,11 @@ export default function UnitSimulatorPanel({
               {result !== null && (
                 <UnitResult
                   result={result}
-                  lockedCards={settings.lockedCards}
+                  lockedCards={[
+                    ...settings.lockedCards,
+                    // レンタル固定中のカードも isLocked として表示する
+                    ...(settings.manualRental && settings.rentalCardName ? [settings.rentalCardName] : []),
+                  ]}
                   customizedCardNames={customizedCardNames}
                   onToggleLock={handleToggleLock}
                   onRemove={handleRemoveCard}

--- a/src/components/unitSimulator/UnitSimulatorPanel.tsx
+++ b/src/components/unitSimulator/UnitSimulatorPanel.tsx
@@ -142,8 +142,7 @@ export default function UnitSimulatorPanel({
       // targetSlotIndexRef が null（連続選択中など）の場合は次に埋まる枠を計算する
       const padded = [...s.manualCards]
       while (padded.length < constant.UNIT_SIZE) padded.push(null)
-      const effectiveTargetIdx =
-        targetSlotIndexRef.current !== null ? targetSlotIndexRef.current : padded.indexOf(null)
+      const effectiveTargetIdx = targetSlotIndexRef.current !== null ? targetSlotIndexRef.current : padded.indexOf(null)
       const isRentalSlot = effectiveTargetIdx === constant.UNIT_SIZE - 1
       if (!isRentalSlot && cardUncapsRef.current[card.name] === UncapType.NotOwned) return false
       return true

--- a/src/contexts/CardContext.tsx
+++ b/src/contexts/CardContext.tsx
@@ -42,6 +42,8 @@ export interface CardUIContextValue {
   unitCardSelectMode?: boolean
   /** サポート選択モード中にサポートが選択可能かどうか判定する関数 */
   isCardEligible?: (card: SupportCard) => boolean
+  /** isCardEligible の更新バージョン（変化時に CardListItem を強制再レンダリングするため） */
+  eligibilityVersion?: number
 }
 
 /** データ層 Context 本体（初期値 null） */

--- a/src/hooks/useUnitSimulator.ts
+++ b/src/hooks/useUnitSimulator.ts
@@ -225,12 +225,12 @@ export function useUnitSimulator(
     const cardCountCustom = loadCardCountCustom()
 
     // 明示的にロックされたサポートのみ固定する（ロックボタンで固定したサポートのみ最適化から除外）
-    // 最適化時はレンタル枠を自動選出するため manualRental を無効化する
+    // manualRental が true（ユーザーがレンタル枠を固定済み）の場合はそのまま維持する
+    // false の場合のみ自動選出のためリセットする
     const merged: UnitSimulatorSettings = {
       ...settings,
       manualCards: settings.manualCards.filter((n): n is string => n !== null),
-      manualRental: false,
-      rentalCardName: null,
+      ...(settings.manualRental ? {} : { manualRental: false, rentalCardName: null }),
     }
     const input = { settings: merged, scoreSettings, cardUncaps, cardCountCustom, allCards, cardByName }
 
@@ -250,10 +250,10 @@ export function useUnitSimulator(
           ? [...optimized.members.filter((m) => !m.isRental).map((m) => m.card.name), rentalName]
           : optimized.members.map((m) => m.card.name)
         const latest = settingsRef.current
+        // manualRental はユーザーの明示的な設定を維持する（上書きしない）
         const synced: UnitSimulatorSettings = {
           ...latest,
           manualCards: ordered,
-          manualRental: rentalName !== null,
           rentalCardName: rentalName,
         }
         setSettings(synced)
@@ -269,11 +269,14 @@ export function useUnitSimulator(
       const scoreSettings: ScoreSettings = loadScoreSettings()
       const cardUncaps = loadUncaps()
       const cardCountCustom = custom ?? loadCardCountCustom()
-      const memberNames = result.members.map((m) => m.card.name)
+      // レンタルメンバーを末尾に配置して evaluateManualUnit で末尾スロット = レンタル枠の判定が正しく動くようにする
+      const rentalMember = result.members.find((m) => m.isRental)
+      const memberNames = rentalMember
+        ? [...result.members.filter((m) => !m.isRental).map((m) => m.card.name), rentalMember.card.name]
+        : result.members.map((m) => m.card.name)
       const recalcSettings: UnitSimulatorSettings = {
         ...settings,
         manualCards: memberNames,
-        // レンタルは末尾スロットから位置ベースで導出されるため rentalCardName の上書きは不要
       }
       const input = { settings: recalcSettings, scoreSettings, cardUncaps, cardCountCustom, allCards, cardByName }
       const updated = evaluateManualUnit(input)

--- a/src/utils/unitSimulator.ts
+++ b/src/utils/unitSimulator.ts
@@ -705,8 +705,11 @@ function autoDesignateRental(
   }
 
   // 全員4凸かつ未所持スワップなし: スコアが最も低いサポートをレンタルとする
-  const lowestIdx = members.reduce((minIdx, m, i) => (m.baseScore < members[minIdx].baseScore ? i : minIdx), 0)
-  return { members, rentalName: members[lowestIdx].card.name }
+  // 固定サポートはレンタル指定の対象外とする（非固定サポートが優先）
+  const nonLockedForRental = members.filter((m) => !lockedNames.has(m.card.name))
+  const rentalCandidatesForFallback = nonLockedForRental.length > 0 ? nonLockedForRental : members
+  const lowestMember = rentalCandidatesForFallback.reduce((min, m) => (m.baseScore < min.baseScore ? m : min))
+  return { members, rentalName: lowestMember.card.name }
 }
 
 /**
@@ -826,10 +829,39 @@ export function optimizeUnit(input: OptimizeInput): UnitResult | null {
   const candidates = prepareCandidates(input, schedule)
   if (candidates.length === 0) return null
 
-  // レンタル枠のサポート（manualRental は現在常に false だが、将来のUI追加に備えて残す）
+  // 手動指定レンタル（manualRental が true の場合は rentalCardName を4凸レンタル固定する）
   let rentalCandidate: CandidateCard | null = null
   if (settings.manualRental && settings.rentalCardName) {
-    const found = candidates.find((c) => c.card.name === settings.rentalCardName)
+    let found = candidates.find((c) => c.card.name === settings.rentalCardName)
+    if (!found) {
+      // 未所持カードがレンタル固定された場合: candidates に含まれないため allCards から直接追加する
+      const card = input.cardByName.get(settings.rentalCardName)
+      if (card) {
+        const customData = input.cardCountCustom?.[card.name]
+        const baseResult = calculateCardParameter(
+          card,
+          enums.UncapType.Four,
+          schedule.effectiveCounts,
+          {},
+          scoreSettings.parameterBonusBase,
+          scoreSettings.includeSelfTrigger,
+          scoreSettings.includePItem,
+          schedule.perLessonValues,
+          customData?.selfTrigger,
+          customData?.pItemCount,
+        )
+        found = {
+          card,
+          uncap: enums.UncapType.Four,
+          baseScore: baseResult.totalIncrease,
+          baseResult,
+          spCategory: getSpCategory(card),
+          paramBonusPercent: getParamBonusPercent(card, enums.UncapType.Four),
+        }
+        // localSearch でも使えるよう candidates に追加する
+        candidates.push(found)
+      }
+    }
     if (found) {
       // レンタル枠は4凸で再計算する
       const result = calculateCardParameter(
@@ -854,23 +886,86 @@ export function optimizeUnit(input: OptimizeInput): UnitResult | null {
 
   const lockedNames = new Set(settings.lockedCards)
 
+  // 固定カード・レンタルカードのタイプ別枚数を集計し、typeCountMax を緩和する
+  // 固定・レンタルカードはタイプ枚数制約に関わらず常に編成に含める（制約は自由枠の選択のみに適用）
+  const forcedTypeCount: Record<enums.ParameterType, number> = {
+    [enums.ParameterType.Vocal]: 0,
+    [enums.ParameterType.Dance]: 0,
+    [enums.ParameterType.Visual]: 0,
+  }
+  for (const name of lockedNames) {
+    const c = candidates.find((c) => c.card.name === name)
+    if (c && PARAMETER_TYPES.includes(c.card.type as enums.ParameterType)) {
+      forcedTypeCount[c.card.type as enums.ParameterType]++
+    }
+  }
+  if (rentalCandidate && PARAMETER_TYPES.includes(rentalCandidate.card.type as enums.ParameterType)) {
+    forcedTypeCount[rentalCandidate.card.type as enums.ParameterType]++
+  }
+  const adjustedTypeCountMax: TypeCountValues = {
+    [enums.ParameterType.Vocal]: Math.max(
+      settings.typeCountMax[enums.ParameterType.Vocal],
+      forcedTypeCount[enums.ParameterType.Vocal],
+    ),
+    [enums.ParameterType.Dance]: Math.max(
+      settings.typeCountMax[enums.ParameterType.Dance],
+      forcedTypeCount[enums.ParameterType.Dance],
+    ),
+    [enums.ParameterType.Visual]: Math.max(
+      settings.typeCountMax[enums.ParameterType.Visual],
+      forcedTypeCount[enums.ParameterType.Visual],
+    ),
+  }
+  // localSearch / autoDesignateRental に渡す input を adjustedTypeCountMax で更新する
+  const adjustedInput: OptimizeInput = { ...input, settings: { ...settings, typeCountMax: adjustedTypeCountMax } }
+
   // Phase 0: レンタルファースト マルチスタート（手動レンタル指定なしの場合のみ）
   // 上位 RENTAL_CANDIDATE_LIMIT 枚を 4凸レンタル固定として greedy + localSearch を実行し、
   // 最良のレンタル候補を特定する。後段の Phase1-4 結果と比較して高スコアの方を採用する。
   let multiStartBest: { members: CandidateCard[]; rentalName: string; score: number } | null = null
   if (!settings.manualRental) {
-    const rentalPool = buildRentalPool(input, schedule, lockedNames)
+    const rentalPool = buildRentalPool(adjustedInput, schedule, lockedNames)
     for (const rentalCand of rentalPool) {
+      // 固定カードで既に original typeCountMax に達しているタイプは自動レンタル候補から除外する
+      // （例: Vo4枚ロック + typeCountMax.Vocal=3 の場合、Vo のレンタル候補はスキップ）
+      const rentalType = rentalCand.card.type as enums.ParameterType
+      if (PARAMETER_TYPES.includes(rentalType) && forcedTypeCount[rentalType] >= settings.typeCountMax[rentalType]) {
+        continue
+      }
+      // Phase 0 では rentalCand ごとに adjustedTypeCountMax を再計算する（rentalCand のタイプを考慮）
+      const phase0ForcedTypeCount: Record<enums.ParameterType, number> = { ...forcedTypeCount }
+      if (PARAMETER_TYPES.includes(rentalCand.card.type as enums.ParameterType)) {
+        phase0ForcedTypeCount[rentalCand.card.type as enums.ParameterType]++
+      }
+      const phase0AdjMax: TypeCountValues = {
+        [enums.ParameterType.Vocal]: Math.max(
+          settings.typeCountMax[enums.ParameterType.Vocal],
+          phase0ForcedTypeCount[enums.ParameterType.Vocal],
+        ),
+        [enums.ParameterType.Dance]: Math.max(
+          settings.typeCountMax[enums.ParameterType.Dance],
+          phase0ForcedTypeCount[enums.ParameterType.Dance],
+        ),
+        [enums.ParameterType.Visual]: Math.max(
+          settings.typeCountMax[enums.ParameterType.Visual],
+          phase0ForcedTypeCount[enums.ParameterType.Visual],
+        ),
+      }
+      const phase0Input: OptimizeInput = {
+        ...input,
+        settings: { ...settings, typeCountMax: phase0AdjMax },
+      }
       const trial = greedyInitial(
         candidates,
         settings.spConstraint,
         settings.typeCountMin,
-        settings.typeCountMax,
+        phase0AdjMax,
         lockedNames,
         rentalCand,
       )
       if (trial.length !== constant.UNIT_SIZE) continue
-      const trialScore = evaluateUnit(trial, input, schedule.effectiveCounts, paramCtx)
+      if (!meetsTypeConstraint(trial, settings.typeCountMin, phase0AdjMax)) continue
+      const trialScore = evaluateUnit(trial, phase0Input, schedule.effectiveCounts, paramCtx)
       if (multiStartBest === null || trialScore > multiStartBest.score) {
         multiStartBest = { members: trial, rentalName: rentalCand.card.name, score: trialScore }
       }
@@ -881,7 +976,7 @@ export function optimizeUnit(input: OptimizeInput): UnitResult | null {
       const searched = localSearch(
         multiStartBest.members,
         candidates,
-        input,
+        adjustedInput,
         rentalLockedNames,
         schedule.effectiveCounts,
         paramCtx,
@@ -889,7 +984,7 @@ export function optimizeUnit(input: OptimizeInput): UnitResult | null {
       multiStartBest = {
         members: searched,
         rentalName: multiStartBest.rentalName,
-        score: evaluateUnit(searched, input, schedule.effectiveCounts, paramCtx),
+        score: evaluateUnit(searched, adjustedInput, schedule.effectiveCounts, paramCtx),
       }
     }
   }
@@ -899,16 +994,18 @@ export function optimizeUnit(input: OptimizeInput): UnitResult | null {
     candidates,
     settings.spConstraint,
     settings.typeCountMin,
-    settings.typeCountMax,
+    adjustedTypeCountMax,
     lockedNames,
     rentalCandidate,
   )
   if (initial.length === 0) return null
 
   // Phase 2: 局所探索（6枚揃っている場合のみ実行）
+  // レンタルカードが固定されている場合は localSearch でも swap されないよう lockedNames に追加する
+  const phase2LockedNames = rentalCandidate ? new Set([...lockedNames, rentalCandidate.card.name]) : lockedNames
   const optimized =
     initial.length === constant.UNIT_SIZE
-      ? localSearch(initial, candidates, input, lockedNames, schedule.effectiveCounts, paramCtx)
+      ? localSearch(initial, candidates, adjustedInput, phase2LockedNames, schedule.effectiveCounts, paramCtx)
       : initial
 
   // Phase 3: レンタル枠の自動選出（手動指定でない場合）
@@ -949,7 +1046,13 @@ export function optimizeUnit(input: OptimizeInput): UnitResult | null {
       unownedAt4.sort((a, b) => b.baseScore - a.baseScore)
       unownedAt4.length = Math.min(unownedAt4.length, constant.UNIT_SIZE * 2)
     }
-    const { members: rentalMembers, rentalName } = autoDesignateRental(optimized, input, schedule, paramCtx, unownedAt4)
+    const { members: rentalMembers, rentalName } = autoDesignateRental(
+      optimized,
+      adjustedInput,
+      schedule,
+      paramCtx,
+      unownedAt4,
+    )
 
     // Phase 4: レンタルスワップ後の局所探索
     // autoDesignateRental が未所持サポートをスワップインした場合、ユニット構成が変わるため
@@ -959,14 +1062,21 @@ export function optimizeUnit(input: OptimizeInput): UnitResult | null {
     let postRental = rentalMembers
     if (rentalChanged && rentalMembers.length === constant.UNIT_SIZE) {
       const phase4Locked = rentalName ? new Set([...lockedNames, rentalName]) : lockedNames
-      postRental = localSearch(rentalMembers, candidates, input, phase4Locked, schedule.effectiveCounts, paramCtx)
+      postRental = localSearch(
+        rentalMembers,
+        candidates,
+        adjustedInput,
+        phase4Locked,
+        schedule.effectiveCounts,
+        paramCtx,
+      )
     }
 
     // レンタルスワップ後の局所探索でレンタル対象が入れ替わった場合はレンタル名を維持する
     const finalRentalName = postRental.some((m) => m.card.name === rentalName) ? rentalName : null
 
     // マルチスタート最良と比較して高スコアの方を採用する
-    const phase4Score = evaluateUnit(postRental, input, schedule.effectiveCounts, paramCtx)
+    const phase4Score = evaluateUnit(postRental, adjustedInput, schedule.effectiveCounts, paramCtx)
     if (multiStartBest && multiStartBest.score > phase4Score) {
       return buildResult(multiStartBest.members, input, schedule.effectiveCounts, multiStartBest.rentalName)
     }
@@ -1133,10 +1243,15 @@ export function evaluateManualUnit(input: OptimizeInput): UnitResult | null {
   const cardNames = settings.manualCards.filter((n): n is string => n !== null)
   if (cardNames.length === 0) return null
 
-  // レンタル枠は末尾スロット（6枠目）のカードから導出する
+  // レンタル枠は末尾スロット（6枠目）のカードから導出する（manualRental に関わらず常に末尾スロットをレンタルとして扱う）
   const padded = [...settings.manualCards]
   while (padded.length < constant.UNIT_SIZE) padded.push(null)
-  const derivedRentalName = settings.manualRental ? padded[constant.UNIT_SIZE - 1] : null
+  let derivedRentalName = padded[constant.UNIT_SIZE - 1]
+  // 6枚未満のとき末尾スロットが null になるため、settings.rentalCardName が現在のカードリストに含まれていれば
+  // それをレンタルとして引き継ぐ（バッジ表示・4凸強制・パラボ計算を正しく保つ）
+  if (derivedRentalName === null && settings.rentalCardName && cardNames.includes(settings.rentalCardName)) {
+    derivedRentalName = settings.rentalCardName
+  }
 
   // スケジュールからアクション回数を導出する
   const schedule = resolveSchedule(scoreSettings)
@@ -1154,10 +1269,12 @@ export function evaluateManualUnit(input: OptimizeInput): UnitResult | null {
     const card = input.cardByName.get(cardName)
     if (!card) continue
 
-    // 凸数: 4凸固定モード or レンタル枠なら4凸、それ以外は設定された凸数
-    const isRental = settings.manualRental && derivedRentalName === cardName
+    // 凸数: 4凸固定モード or 末尾スロット（レンタル枠）なら4凸、それ以外は設定された凸数
+    const isRentalSlot = derivedRentalName === cardName
     const uncap =
-      scoreSettings.useFixedUncap || isRental ? enums.UncapType.Four : (cardUncaps[card.name] ?? constant.DEFAULT_UNCAP)
+      scoreSettings.useFixedUncap || isRentalSlot
+        ? enums.UncapType.Four
+        : (cardUncaps[card.name] ?? constant.DEFAULT_UNCAP)
     const customData = input.cardCountCustom?.[card.name]
     const baseResult = calculateCardParameter(
       card,
@@ -1184,5 +1301,7 @@ export function evaluateManualUnit(input: OptimizeInput): UnitResult | null {
 
   if (candidates.length === 0) return null
 
-  return buildResult(candidates, evalInput, effectiveCounts)
+  // derivedRentalName を autoRentalName として渡し、末尾スロットのカードに isRental: true をセットする
+  // manualRental の状態に関わらず末尾スロットのカードは常にレンタルとして表示する
+  return buildResult(candidates, evalInput, effectiveCounts, derivedRentalName ?? undefined)
 }


### PR DESCRIPTION
## 概要

ユニットシミュレーターのレンタル枠固定・タイプ制約・未所持カード選択制限・UIバグに関する複数のバグを修正する。

## 変更内容

### タイプ制約緩和（adjustedTypeCountMax 方式）
- `effectiveManualRental` による自動解除を廃止
- 固定・レンタルカードのタイプ枚数が `typeCountMax` を超える場合は上限を緩和

### 自動レンタル抑制
- Vo固定で上限に達している場合は自動レンタルの Vo 選出を抑制
- Phase 0 フィルター + `autoDesignateRental` フォールバックを非固定メンバー優先に変更

### 6枠未満ユニットの修正
- `evaluateManualUnit` で `settings.rentalCardName` へのフォールバックを追加
- レンタルバッジ・4凸スコアが消える問題を修正

### 選択モード中のスコアモーダル無効化
- `onScoreClick` を `unitCardSelectMode=true` の間 no-op に変更

### 位置ベースのレンタル判定修正
- `addCard` / `handleToggleLock` / `handleRemoveCard` の位置ベース判定を修正

### manualRental 上書きバグ修正
- `optimizeRemaining` が `manualRental` を上書きするバグを修正

### 未所持カード選択制限
- レンタル枠（第6スロット）以外では `NotOwned` カードを選択不可に
- 連続選択時の次枠計算で正しくレンタル枠を判定
- カードリスト再レンダリングのため `eligibilityVersion` をコンテキストに追加

## 確認事項

- [x] 動作確認済み
- [x] 1584 tests passed
- [x] prettier / lint / tsc エラーなし
