### PR TITLE
feat(ui): モバイル向け UX 改善と最適編成パネル整理

### DIFF
--- a/src/components/unitSimulator/UnitSimulatorPanel.tsx
+++ b/src/components/unitSimulator/UnitSimulatorPanel.tsx
@@ -5,7 +5,7 @@
  * 最適編成を表示する。
  */
 import { useTranslation } from 'react-i18next'
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { SidePanelLayout } from '../ui/SidePanelLayout'
 import CollapsibleSection from '../ui/CollapsibleSection'
@@ -16,8 +16,7 @@ import UnitResult from './UnitResult'
 import UnitSlotEditor from './UnitSlotEditor'
 import { useUnitSimulator } from '../../hooks/useUnitSimulator'
 import type { CardCountCustomState } from '../../hooks/useCardCountCustom'
-import { useAccordionState } from '../../hooks'
-import { ButtonSizeType, CollapsibleVariantType, PlanType, SimulatorSectionKey, UncapType } from '../../types/enums'
+import { ButtonSizeType, CollapsibleVariantType, PlanType, UncapType } from '../../types/enums'
 import type { SupportCard, ScoreSettings } from '../../types/card'
 import * as constant from '../../constant'
 import { resolveParamCap } from '../../data/score/paramCap'
@@ -201,12 +200,8 @@ export default function UnitSimulatorPanel({
     [scoreSettings.scenario, scoreSettings.difficulty, settings.paramCapOverride],
   )
 
-  // アコーディオン
-  const { state: sections, toggle } = useAccordionState({
-    [SimulatorSectionKey.Settings]: true,
-    [SimulatorSectionKey.Slots]: true,
-    [SimulatorSectionKey.Result]: true,
-  })
+  // 育成プラン設定セクションの開閉状態
+  const [isSettingsOpen, setIsSettingsOpen] = useState(true)
 
   /** 一覧から選択モードの切り替え */
   const handleToggleSelectMode = useCallback(() => {
@@ -291,8 +286,8 @@ export default function UnitSimulatorPanel({
                 {t('unit.settings.title')} <HelpTooltip text={t('unit.settings.title_tip')} />
               </>
             }
-            isOpen={sections[SimulatorSectionKey.Settings]}
-            onToggle={() => toggle(SimulatorSectionKey.Settings)}
+            isOpen={isSettingsOpen}
+            onToggle={() => setIsSettingsOpen((prev) => !prev)}
             variant={CollapsibleVariantType.Panel}
           >
             <div className="mt-2">
@@ -308,108 +303,104 @@ export default function UnitSimulatorPanel({
 
         {/* 最適編成セクション */}
         <div className={constant.SECTION_DIVIDER}>
-          <CollapsibleSection
-            title={t('ui.settings.unit_simulator')}
-            isOpen={sections[SimulatorSectionKey.Slots]}
-            onToggle={() => toggle(SimulatorSectionKey.Slots)}
-            variant={CollapsibleVariantType.Panel}
-          >
-            <div className="mt-2 space-y-4">
-              {/* アクションボタン（上部） */}
-              <div className="flex gap-2">
-                {/* 最適化ボタン（ロック済み以外を最適編成で埋める） */}
-                <button
-                  onClick={() => {
-                    if (isCalculating) {
-                      if (window.confirm(t('unit.cancel_confirm'))) {
-                        cancelOptimize()
-                      }
-                      return
+          <div className="flex items-center gap-1.5 w-full text-left text-xs font-black text-slate-500 uppercase tracking-widest py-1">
+            {t('ui.settings.unit_simulator')}
+          </div>
+          <div className="mt-2 space-y-4">
+            {/* アクションボタン（上部） */}
+            <div className="flex gap-2">
+              {/* 最適化ボタン（ロック済み以外を最適編成で埋める） */}
+              <button
+                onClick={() => {
+                  if (isCalculating) {
+                    if (window.confirm(t('unit.cancel_confirm'))) {
+                      cancelOptimize()
                     }
-                    // サポート選択モード中なら解除する
-                    if (unitCardSelectMode) {
-                      setUnitCardSelectMode(false)
-                      targetSlotIndexRef.current = null
-                    }
-                    optimizeRemaining()
-                  }}
-                  title={t('unit.auto_optimize_tip')}
-                  className={`flex-1 py-2 rounded-xl text-xs font-bold transition-colors ${
-                    isCalculating
-                      ? 'bg-amber-500 text-white hover:bg-amber-600 active:bg-amber-700'
-                      : 'bg-blue-600 text-white hover:bg-blue-700 active:bg-blue-800'
-                  }`}
-                >
-                  {isCalculating && exhaustiveProgress !== null
-                    ? t('unit.progress_count', {
-                        done: exhaustiveProgress.done.toLocaleString(),
-                        total: exhaustiveProgress.total.toLocaleString(),
-                      })
-                    : isCalculating
-                      ? t('unit.calculating')
-                      : t('unit.auto_optimize')}
-                </button>
-              </div>
-
-              {/* 候補なし警告 */}
-              {noCandidates && (
-                <div className="rounded-lg bg-amber-50 border border-amber-200 px-3 py-2 text-xs text-amber-700">
-                  {t('unit.no_candidates')}
-                </div>
-              )}
-
-              {/* スロットエディター（結果表示時は非表示） */}
-              {!isCalculating && result === null && (
-                <UnitSlotEditor
-                  cards={settings.manualCards}
-                  onRemoveCard={handleRemoveCard}
-                  onStartSelect={handleSlotSelect}
-                  selectMode={unitCardSelectMode}
-                  rentalCardName={settings.rentalCardName}
-                />
-              )}
-
-              {/* 計算結果 */}
-              {result !== null && (
-                <UnitResult
-                  result={result}
-                  lockedCards={[
-                    ...settings.lockedCards,
-                    // レンタル固定中のカードも isLocked として表示する
-                    ...(settings.manualRental && settings.rentalCardName ? [settings.rentalCardName] : []),
-                  ]}
-                  customizedCardNames={customizedCardNames}
-                  onToggleLock={handleToggleLock}
-                  onRemove={handleRemoveCard}
-                  cardCountCustom={countCustom.cardCountCustom}
-                  onSelfTriggerChange={countCustom.setSelfTrigger}
-                  onRemoveSelfTrigger={countCustom.removeSelfTrigger}
-                  onPItemCountChange={countCustom.setPItemCount}
-                  onRemovePItemCount={countCustom.removePItemCount}
-                  onClearCardCustom={countCustom.clearCardCustom}
-                  scenario={scoreSettings.scenario}
-                  difficulty={scoreSettings.difficulty}
-                  scheduleSelections={scoreSettings.scheduleSelections}
-                  useCustomMode={scoreSettings.useCustomMode}
-                  customClassBonus={scoreSettings.customClassBonus}
-                  customNonBonusGain={scoreSettings.customNonBonusGain}
-                  initialParams={settings.initialParams}
-                  paramCapOverride={settings.paramCapOverride}
-                  manualCards={settings.manualCards}
-                  onStartSelect={handleSlotSelect}
-                  selectMode={unitCardSelectMode}
-                  isCalculating={isCalculating}
-                />
-              )}
-
-              {/* 計算結果なし */}
-              {result === null && hasCalculated && !isCalculating && (
-                <div className="text-center py-4">
-                  <p className="text-xs text-slate-500">{t('unit.no_result')}</p>
-                </div>
-              )}
+                    return
+                  }
+                  // サポート選択モード中なら解除する
+                  if (unitCardSelectMode) {
+                    setUnitCardSelectMode(false)
+                    targetSlotIndexRef.current = null
+                  }
+                  optimizeRemaining()
+                }}
+                title={t('unit.auto_optimize_tip')}
+                className={`flex-1 py-2 rounded-xl text-xs font-bold transition-colors ${
+                  isCalculating
+                    ? 'bg-amber-500 text-white hover:bg-amber-600 active:bg-amber-700'
+                    : 'bg-blue-600 text-white hover:bg-blue-700 active:bg-blue-800'
+                }`}
+              >
+                {isCalculating && exhaustiveProgress !== null
+                  ? t('unit.progress_count', {
+                      done: exhaustiveProgress.done.toLocaleString(),
+                      total: exhaustiveProgress.total.toLocaleString(),
+                    })
+                  : isCalculating
+                    ? t('unit.calculating')
+                    : t('unit.auto_optimize')}
+              </button>
             </div>
-          </CollapsibleSection>
+
+            {/* 候補なし警告 */}
+            {noCandidates && (
+              <div className="rounded-lg bg-amber-50 border border-amber-200 px-3 py-2 text-xs text-amber-700">
+                {t('unit.no_candidates')}
+              </div>
+            )}
+
+            {/* スロットエディター（結果表示時は非表示） */}
+            {!isCalculating && result === null && (
+              <UnitSlotEditor
+                cards={settings.manualCards}
+                onRemoveCard={handleRemoveCard}
+                onStartSelect={handleSlotSelect}
+                selectMode={unitCardSelectMode}
+                rentalCardName={settings.rentalCardName}
+              />
+            )}
+
+            {/* 計算結果 */}
+            {result !== null && (
+              <UnitResult
+                result={result}
+                lockedCards={[
+                  ...settings.lockedCards,
+                  // レンタル固定中のカードも isLocked として表示する
+                  ...(settings.manualRental && settings.rentalCardName ? [settings.rentalCardName] : []),
+                ]}
+                customizedCardNames={customizedCardNames}
+                onToggleLock={handleToggleLock}
+                onRemove={handleRemoveCard}
+                cardCountCustom={countCustom.cardCountCustom}
+                onSelfTriggerChange={countCustom.setSelfTrigger}
+                onRemoveSelfTrigger={countCustom.removeSelfTrigger}
+                onPItemCountChange={countCustom.setPItemCount}
+                onRemovePItemCount={countCustom.removePItemCount}
+                onClearCardCustom={countCustom.clearCardCustom}
+                scenario={scoreSettings.scenario}
+                difficulty={scoreSettings.difficulty}
+                scheduleSelections={scoreSettings.scheduleSelections}
+                useCustomMode={scoreSettings.useCustomMode}
+                customClassBonus={scoreSettings.customClassBonus}
+                customNonBonusGain={scoreSettings.customNonBonusGain}
+                initialParams={settings.initialParams}
+                paramCapOverride={settings.paramCapOverride}
+                manualCards={settings.manualCards}
+                onStartSelect={handleSlotSelect}
+                selectMode={unitCardSelectMode}
+                isCalculating={isCalculating}
+              />
+            )}
+
+            {/* 計算結果なし */}
+            {result === null && hasCalculated && !isCalculating && (
+              <div className="text-center py-4">
+                <p className="text-xs text-slate-500">{t('unit.no_result')}</p>
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </SidePanelLayout>

--- a/src/constant/common.ts
+++ b/src/constant/common.ts
@@ -88,4 +88,4 @@ export const SP_TYPE_COUNT_CACHE_MAX = 500
 /** タイプ別編成枚数のデフォルト最小値 */
 export const TYPE_COUNT_MIN_DEFAULT = 0
 /** タイプ別編成枚数のデフォルト最大値 */
-export const TYPE_COUNT_MAX_DEFAULT = 3
+export const TYPE_COUNT_MAX_DEFAULT = 4

--- a/src/index.css
+++ b/src/index.css
@@ -33,3 +33,12 @@ body {
 .scrollbar-none::-webkit-scrollbar {
   display: none;
 }
+
+/* iOS Safari でのテキストフィールドズームイン防止（font-size < 16px はズームを引き起こすため） */
+@media (max-width: 767px) {
+  input,
+  select,
+  textarea {
+    font-size: 16px;
+  }
+}

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -1538,19 +1538,6 @@ export const ScoreDetailSectionKey = {
 export type ScoreDetailSectionKey = (typeof ScoreDetailSectionKey)[keyof typeof ScoreDetailSectionKey]
 
 /**
- * 最適編成パネルのセクションキー。
- */
-export const SimulatorSectionKey = {
-  /** 編成設定 */
-  Settings: 'settings',
-  /** スロット編集 */
-  Slots: 'slots',
-  /** 結果 */
-  Result: 'result',
-} as const
-export type SimulatorSectionKey = (typeof SimulatorSectionKey)[keyof typeof SimulatorSectionKey]
-
-/**
  * ユーザーサポートフォームの折りたたみセクションキー。
  */
 export const UserFormSectionKey = {


### PR DESCRIPTION
## 概要

モバイル UX の改善と最適編成パネルの整理。

## 変更内容

- タイプ別最大枚数のデフォルト値を 3 → 4 に変更
- iOS Safari でテキストフィールドをタップした際のズームイン防止（`font-size: 16px` を強制）
- 最適編成（Slots）セクションを常時表示の単純ヘッダーに変更（誤操作防止）
- 育成プラン設定（Settings）セクションは開閉可能のまま維持
- `useAccordionState` を `useState` に置き換え（Settings 1つのみのため）
- `SimulatorSectionKey` enum を削除（全参照がなくなったため）

## 確認事項
- [x] 動作確認済み
