### PR TITLE
fix(score): HIF選抜試験1〜3の週判定を修正

### DIFF
--- a/src/__tests__/utils/calculator/parameterBonus.test.ts
+++ b/src/__tests__/utils/calculator/parameterBonus.test.ts
@@ -13,6 +13,7 @@ import {
   getParameterBonusBreakdown,
 } from '../../../utils/calculator/parameterBonus'
 import * as enums from '../../../types/enums'
+import { HIF_EXAM_LABEL_KEYS } from '../../../data'
 
 // テストデータは実際のシナリオ/難易度を使用（data/score/lesson.ts に依存）
 
@@ -199,5 +200,20 @@ describe('getParameterBonusBreakdown', () => {
     expect(result).toHaveLength(2)
     expect(result[0].attribute).toBe(enums.ParameterType.Vocal)
     expect(result[1].attribute).toBe(enums.ParameterType.Dance)
+  })
+
+  it('HIF 選抜試験1〜3の内訳行を週7/13/20に追加する', () => {
+    const result = getParameterBonusBreakdown({}, enums.ScenarioType.Hif, enums.DifficultyType.None)
+    const examRows = result.filter((row) => row.rowKind?.kind === enums.BreakdownRowKindType.Exam)
+
+    expect(HIF_EXAM_LABEL_KEYS).toEqual([
+      'ui.settings.hif_exam_ratio_exam1',
+      'ui.settings.hif_exam_ratio_exam2',
+      'ui.settings.hif_exam_ratio_exam3',
+    ])
+    expect(examRows.map((row) => row.week)).toEqual([7, 13, 20])
+    expect(
+      examRows.map((row) => (row.rowKind !== undefined && 'examIndex' in row.rowKind ? row.rowKind.examIndex : -1)),
+    ).toEqual([0, 1, 2])
   })
 })

--- a/src/data/score/schedule.ts
+++ b/src/data/score/schedule.ts
@@ -312,8 +312,8 @@ export const HIF_EXAM_LABEL_KEYS: readonly TranslationKey[] = (data[ScenarioType
     (entry) =>
       entry.stage === HifStage.Selection &&
       entry.fixed &&
-      entry.activities.includes(ActivityIdType.MidExam) &&
-      entry.week_label !== undefined,
+      entry.week_label !== undefined &&
+      entry.activities.some((id) => id === ActivityIdType.MidExam || id === ActivityIdType.FinalExam),
   )
   .map((entry) => entry.week_label as TranslationKey)
 

--- a/src/utils/hifScheduleHelpers.ts
+++ b/src/utils/hifScheduleHelpers.ts
@@ -58,10 +58,17 @@ export function normalizeHifLessonActivityForPairMode(activityId: enums.Activity
  * スケジュールデータから HIF選抜試験の週番号一覧を抽出する。
  *
  * @param scheduleData - スケジュールデータ全件
- * @returns 中間試験が含まれる週番号の配列
+ * @returns HIF選抜試験1〜3の週番号の配列
  */
 export function getHifExamWeeks(scheduleData: ScheduleWeekData[]): number[] {
-  return scheduleData.filter((w) => w.activities.some((a) => a.id === enums.ActivityIdType.MidExam)).map((w) => w.week)
+  return scheduleData
+    .filter(
+      (w) =>
+        w.stage === enums.HifStage.Selection &&
+        w.fixed &&
+        w.activities.some((a) => a.id === enums.ActivityIdType.MidExam || a.id === enums.ActivityIdType.FinalExam),
+    )
+    .map((w) => w.week)
 }
 
 /**


### PR DESCRIPTION
## 概要
- HIF選抜試験の週判定でMidExamだけを拾っていたため、FinalExam扱いの選抜試験1/2も対象に含めるよう修正
- 選抜試験1〜3が週7/13/20に出ることをテストで固定

## 確認
- npm test -- --run src/__tests__/utils/calculator/parameterBonus.test.ts
- npm run build