### PR TITLE
feat(unit): コンテスト用除外設定を分割

### DIFF
--- a/src/__tests__/utils/unitOptimizer/candidatePreparation.test.ts
+++ b/src/__tests__/utils/unitOptimizer/candidatePreparation.test.ts
@@ -70,45 +70,87 @@ function makeSettings(overrides: Partial<UnitSimulatorSettings> = {}): UnitSimul
     lockedCards: [],
     manualCards: [],
     initialParams: { vocal: 0, dance: 0, visual: 0 },
-    excludeContestBlockedCards: true,
+    excludeContestSkillCards: true,
+    excludeContestPItems: true,
     ...overrides,
   }
 }
 
 describe('候補準備のコンテスト用除外', () => {
-  it('スキルカード持ちとメモリ化Pアイテム持ちを通常候補とレンタル候補から除外する', () => {
-    const normal = makeCard('通常サポート')
-    const skillCard = makeCard('スキルカード持ち', { skill_card: testSkillCard })
-    const memorizablePItem = makeCard('メモリ化Pアイテム持ち', {
-      p_item: {
-        name: 'メモリ化アイテム',
-        rarity: enums.PItemRarityType.SR,
-        memory: enums.PItemMemoryType.Memorizable,
-      },
-    })
-    const nonMemorizablePItem = makeCard('メモリ化不可Pアイテム持ち', {
-      p_item: {
-        name: 'メモリ化不可アイテム',
-        rarity: enums.PItemRarityType.SR,
-        memory: enums.PItemMemoryType.NonMemorizable,
-      },
-    })
-    const allCards = [normal, skillCard, memorizablePItem, nonMemorizablePItem]
-    const input = {
-      settings: makeSettings(),
+  const normal = makeCard('通常サポート')
+  const skillCard = makeCard('スキルカード持ち', { skill_card: testSkillCard })
+  const memorizablePItem = makeCard('メモリ化Pアイテム持ち', {
+    p_item: {
+      name: 'メモリ化アイテム',
+      rarity: enums.PItemRarityType.SR,
+      memory: enums.PItemMemoryType.Memorizable,
+    },
+  })
+  const nonMemorizablePItem = makeCard('メモリ化不可Pアイテム持ち', {
+    p_item: {
+      name: 'メモリ化不可アイテム',
+      rarity: enums.PItemRarityType.SR,
+      memory: enums.PItemMemoryType.NonMemorizable,
+    },
+  })
+  const allCards = [normal, skillCard, memorizablePItem, nonMemorizablePItem]
+  const schedule = { effectiveCounts: {}, perLessonValues: undefined }
+
+  function makeInput(settings: UnitSimulatorSettings) {
+    return {
+      settings,
       scoreSettings: createDefaultSettings(),
       cardUncaps: {},
       cardCountCustom: {},
       allCards,
       cardByName: new Map(allCards.map((card) => [card.name, card])),
     }
-    const schedule = { effectiveCounts: {}, perLessonValues: undefined }
+  }
+
+  it('スキルカード持ちとメモリ化Pアイテム持ちを通常候補とレンタル候補から除外する', () => {
+    const input = makeInput(makeSettings())
 
     const candidates = prepareCandidates(input, schedule)
     const rentalPool = createRentalPool(input, schedule, new Set(), 10)
 
     expect(candidates.map((candidate) => candidate.card.name)).toEqual(['通常サポート', 'メモリ化不可Pアイテム持ち'])
     expect(rentalPool.map((candidate) => candidate.card.name)).toEqual(['通常サポート', 'メモリ化不可Pアイテム持ち'])
+  })
+
+  it('スキルカード除外だけ有効ならメモリ化Pアイテム持ちは候補に残す', () => {
+    const input = makeInput(makeSettings({ excludeContestSkillCards: true, excludeContestPItems: false }))
+
+    const candidates = prepareCandidates(input, schedule)
+    const rentalPool = createRentalPool(input, schedule, new Set(), 10)
+
+    expect(candidates.map((candidate) => candidate.card.name)).toEqual([
+      '通常サポート',
+      'メモリ化Pアイテム持ち',
+      'メモリ化不可Pアイテム持ち',
+    ])
+    expect(rentalPool.map((candidate) => candidate.card.name)).toEqual([
+      '通常サポート',
+      'メモリ化Pアイテム持ち',
+      'メモリ化不可Pアイテム持ち',
+    ])
+  })
+
+  it('メモリ化Pアイテム除外だけ有効ならスキルカード持ちは候補に残す', () => {
+    const input = makeInput(makeSettings({ excludeContestSkillCards: false, excludeContestPItems: true }))
+
+    const candidates = prepareCandidates(input, schedule)
+    const rentalPool = createRentalPool(input, schedule, new Set(), 10)
+
+    expect(candidates.map((candidate) => candidate.card.name)).toEqual([
+      '通常サポート',
+      'スキルカード持ち',
+      'メモリ化不可Pアイテム持ち',
+    ])
+    expect(rentalPool.map((candidate) => candidate.card.name)).toEqual([
+      '通常サポート',
+      'スキルカード持ち',
+      'メモリ化不可Pアイテム持ち',
+    ])
   })
 
   it('通常ロックされたサポートはコンテスト用除外対象でも固定候補として残す', () => {

--- a/src/components/unitSimulator/UnitSettings.tsx
+++ b/src/components/unitSimulator/UnitSettings.tsx
@@ -141,10 +141,18 @@ export default function UnitSettings({ settings, onChange, resolvedParamCap }: U
     [settings, onChange],
   )
 
-  /** コンテスト用除外設定変更 */
-  const handleContestExcludeChange = useCallback(
+  /** コンテスト用スキルカード除外設定変更 */
+  const handleContestSkillExcludeChange = useCallback(
     (checked: boolean) => {
-      onChange({ ...settings, excludeContestBlockedCards: checked })
+      onChange({ ...settings, excludeContestSkillCards: checked })
+    },
+    [settings, onChange],
+  )
+
+  /** コンテスト用Pアイテム除外設定変更 */
+  const handleContestPItemExcludeChange = useCallback(
+    (checked: boolean) => {
+      onChange({ ...settings, excludeContestPItems: checked })
     },
     [settings, onChange],
   )
@@ -339,10 +347,16 @@ export default function UnitSettings({ settings, onChange, resolvedParamCap }: U
           description={t('unit.settings.unify_rental_lock_tip')}
         />
         <CheckboxField
-          label={t('unit.settings.exclude_contest_blocked_cards')}
-          checked={!!settings.excludeContestBlockedCards}
-          onChange={handleContestExcludeChange}
-          description={t('unit.settings.exclude_contest_blocked_cards_tip')}
+          label={t('unit.settings.exclude_contest_skill_cards')}
+          checked={!!settings.excludeContestSkillCards}
+          onChange={handleContestSkillExcludeChange}
+          description={t('unit.settings.exclude_contest_skill_cards_tip')}
+        />
+        <CheckboxField
+          label={t('unit.settings.exclude_contest_p_items')}
+          checked={!!settings.excludeContestPItems}
+          onChange={handleContestPItemExcludeChange}
+          description={t('unit.settings.exclude_contest_p_items_tip')}
         />
         <div className="flex items-center justify-between gap-2">
           <span className={constant.SECTION_HEADING_SM_PX}>

--- a/src/hooks/useUnitSimulator.ts
+++ b/src/hooks/useUnitSimulator.ts
@@ -61,7 +61,8 @@ const defaultSettings: UnitSimulatorSettings = {
   initialParams: { vocal: 0, dance: 0, visual: 0 },
   paramCapOverride: null,
   unifyRentalLock: false,
-  excludeContestBlockedCards: false,
+  excludeContestSkillCards: false,
+  excludeContestPItems: false,
   exhaustiveCandidateLimit: constant.EXHAUSTIVE_CANDIDATE_LIMIT,
 }
 

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -836,8 +836,10 @@
       "param_cap_tip": "パラメータ上限値を設定します",
       "unify_rental_lock": "レンタル枠と通常枠のロックを区別しない",
       "unify_rental_lock_tip": "有効時、ロックしたカードをレンタル枠・通常枠の区別なく扱い、どの配置が最適かも含めて探索します",
-      "exclude_contest_blocked_cards": "スキルカード・メモリ化Pアイテム持ちを除外",
-      "exclude_contest_blocked_cards_tip": "スキルカードを獲得する、メモリーに入るPアイテムを獲得するサポートを最適化候補から除外します",
+      "exclude_contest_skill_cards": "スキルカード持ちを除外",
+      "exclude_contest_skill_cards_tip": "スキルカードを獲得するサポートを最適化候補から除外します",
+      "exclude_contest_p_items": "メモリ化Pアイテム持ちを除外",
+      "exclude_contest_p_items_tip": "メモリーに入るPアイテムを獲得するサポートを最適化候補から除外します",
       "candidate_limit": "全サポート 上位枚数",
       "candidate_limit_tip": "全サポートの点数上位何枚で最適化を実施するか設定します。枚数が多いほど精度が上がりますが計算時間が長くなります"
     },

--- a/src/types/unit.ts
+++ b/src/types/unit.ts
@@ -54,8 +54,10 @@ export interface UnitSimulatorSettings {
   paramCapOverride?: number | null
   /** レンタル枠のロックとそれ以外の枠のロックを区別しないか */
   unifyRentalLock?: boolean
-  /** コンテスト用にスキルカード獲得・メモリ化Pアイテム獲得サポートを候補から除外するか */
-  excludeContestBlockedCards?: boolean
+  /** コンテスト用にスキルカード獲得サポートを候補から除外するか */
+  excludeContestSkillCards?: boolean
+  /** コンテスト用にメモリ化Pアイテム獲得サポートを候補から除外するか */
+  excludeContestPItems?: boolean
   /** 総当たり最適化の候補上位枚数（未設定時は既定値） */
   exhaustiveCandidateLimit?: number
 }

--- a/src/utils/unitOptimizer/candidatePreparation.ts
+++ b/src/utils/unitOptimizer/candidatePreparation.ts
@@ -82,22 +82,19 @@ interface RentalBranchContext {
 /**
  * コンテスト編成で避けたい獲得物を持つサポートか判定する
  *
- * @param card - 判定するサポート
- * @returns スキルカード獲得またはメモリ化Pアイテム獲得を持つ場合 true
- */
-function hasContestBlockedReward(card: SupportCard): boolean {
-  return card.skill_card !== null || card.p_item?.memory === enums.PItemMemoryType.Memorizable
-}
-
-/**
- * コンテスト用除外設定により候補から外すべきサポートか判定する
+ * スキルカードとメモリ化Pアイテムは個別に除外できる。
  *
  * @param settings - 現在のユニット設定
  * @param card - 判定するサポート
- * @returns 除外対象なら true
+ * @returns 設定に応じた除外対象なら true
  */
 function shouldExcludeForContest(settings: UnitSimulatorSettings, card: SupportCard): boolean {
-  return !!settings.excludeContestBlockedCards && hasContestBlockedReward(card)
+  const excludeSkillCards = !!settings.excludeContestSkillCards
+  const excludePItems = !!settings.excludeContestPItems
+  return (
+    (excludeSkillCards && card.skill_card !== null) ||
+    (excludePItems && card.p_item?.memory === enums.PItemMemoryType.Memorizable)
+  )
 }
 
 /** evaluateUnit 高速化用のアビリティシナジー情報 */


### PR DESCRIPTION
## 概要
- コンテスト用除外設定を「スキルカード持ち」と「メモリ化Pアイテム持ち」に分割
- スキルカード持ちだけを除外し、Pアイテム持ちは候補に残せるように変更
- 旧excludeContestBlockedCardsのローカルストレージ移行は行わず、余分な保存キーは無視

## 確認
- npm test -- --run src/__tests__/utils/unitOptimizer/candidatePreparation.test.ts
- npm run build