### PR TITLE
fix(pwa): Service Workerの更新反映を安定化

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,4 +1,6 @@
 /** Vite 環境変数の型定義。.env ファイルで設定する値を定義する。 */
+/// <reference types="vite-plugin-pwa/client" />
+
 interface ImportMetaEnv {
   /** Google Analytics トラッキングID */
   readonly VITE_GA_ID: string

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,18 @@
 /** アプリケーションのエントリーポイント */
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { registerSW } from 'virtual:pwa-register'
 import './i18n'
 import './index.css'
 import App from './App.tsx'
 import { ErrorBoundary } from './components/ui/ErrorBoundary.tsx'
+
+registerSW({
+  immediate: true,
+  onRegisterError(error) {
+    console.error('Service Worker registration failed:', error)
+  },
+})
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -73,7 +73,7 @@ export default defineConfig(({ mode }) => {
         manifest: false,
         scope: basePath,
         registerType: 'autoUpdate',
-        injectRegister: 'script-defer',
+        injectRegister: null,
         workbox: {
           skipWaiting: true,
           clientsClaim: true,


### PR DESCRIPTION
## 概要
- PWAのService Worker登録をアプリ側で明示的に行うよう変更
- vite-plugin-pwaの自動registerSW.js注入を停止
- デプロイ直後に古いキャッシュ/遅延チャンクが残ってエラーになる症状を抑制

## 確認
- npm run build
- npm run test:run