### PR TITLE
chore(data): 新カード2枚追加（どーなっちゃうの～？ / ゆずれないもの）

### DIFF
--- a/src/__tests__/utils/abilityValueResolver.test.ts
+++ b/src/__tests__/utils/abilityValueResolver.test.ts
@@ -19,7 +19,7 @@ import {
 } from '../../types/enums'
 import { getAvailableAbilities, getStages, getSchedule } from '../../data/score/abilityValue'
 import { resolveAbilityValues } from '../../utils/abilityValueResolver'
-import { SLOT1_OPTIONS, SLOT3_OPTIONS, SLOT6_OPTIONS, isFixedSlot } from '../../data/card/abilitySlot'
+import { ABILITY_MAX_COUNT, SLOT1_OPTIONS, SLOT3_OPTIONS, SLOT6_OPTIONS, isFixedSlot } from '../../data/card/abilitySlot'
 import type { SupportCard, Ability } from '../../types/card'
 
 /** テスト用のダミーサポートを生成する */
@@ -185,5 +185,13 @@ describe('固定スロット', () => {
     for (const nameKey of SLOT6_OPTIONS[tier]) {
       expect(available, `${tier} に ${nameKey} がない`).toContain(nameKey)
     }
+  })
+
+  it('サポート追加フォーム用の回数付きアビリティが選択可能で既定回数を持つ', () => {
+    expect(getAvailableAbilities(RarityTierType.SSR)).toContain(AbilityNameKeyType.SpecialTraining)
+    expect(ABILITY_MAX_COUNT[AbilityNameKeyType.SpecialTraining]).toBe(3)
+
+    expect(getAvailableAbilities(RarityTierType.SR)).toContain(AbilityNameKeyType.ActivitySupplyGiftCount)
+    expect(ABILITY_MAX_COUNT[AbilityNameKeyType.ActivitySupplyGiftCount]).toBe(2)
   })
 })

--- a/src/__tests__/utils/abilityValueResolver.test.ts
+++ b/src/__tests__/utils/abilityValueResolver.test.ts
@@ -19,7 +19,13 @@ import {
 } from '../../types/enums'
 import { getAvailableAbilities, getStages, getSchedule } from '../../data/score/abilityValue'
 import { resolveAbilityValues } from '../../utils/abilityValueResolver'
-import { ABILITY_MAX_COUNT, SLOT1_OPTIONS, SLOT3_OPTIONS, SLOT6_OPTIONS, isFixedSlot } from '../../data/card/abilitySlot'
+import {
+  ABILITY_MAX_COUNT,
+  SLOT1_OPTIONS,
+  SLOT3_OPTIONS,
+  SLOT6_OPTIONS,
+  isFixedSlot,
+} from '../../data/card/abilitySlot'
 import type { SupportCard, Ability } from '../../types/card'
 
 /** テスト用のダミーサポートを生成する */

--- a/src/data/json/cards.json
+++ b/src/data/json/cards.json
@@ -22553,5 +22553,208 @@
       "custom_cap": 1,
       "custom_slot": []
     }
+  },
+  {
+    "name": "どーなっちゃうの～？",
+    "rarity": "ssr",
+    "plan": "anomaly",
+    "type": "visual",
+    "parameter_type": "visual",
+    "source": "unit_limited",
+    "release_date": "2026/06/15",
+    "abilities": [
+      {
+        "name_key": "parameter_bonus",
+        "trigger_key": "vi_parameter_bonus",
+        "parameter_type": "visual",
+        "values": {},
+        "is_percentage": true,
+        "is_parameter_bonus": true
+      },
+      {
+        "name_key": "special_training",
+        "trigger_key": "special_training",
+        "parameter_type": "visual",
+        "values": {},
+        "max_count": 3
+      },
+      {
+        "name_key": "support_rate",
+        "trigger_key": "support_rate",
+        "values": {},
+        "is_percentage": true,
+        "skip_calculation": true
+      },
+      {
+        "name_key": "sp_lesson_end",
+        "trigger_key": "vi_sp_lesson_end",
+        "parameter_type": "visual",
+        "values": {}
+      },
+      {
+        "name_key": "activity_supply_gift_count",
+        "trigger_key": "activity_supply_gift_count",
+        "parameter_type": "visual",
+        "values": {},
+        "max_count": 2
+      },
+      {
+        "name_key": "event_boost",
+        "trigger_key": "event_boost",
+        "values": {},
+        "is_percentage": true,
+        "is_event_boost": true
+      }
+    ],
+    "events": [
+      {
+        "release": "initial",
+        "effect_type": "p_item",
+        "title": "恋心のゆくえ"
+      },
+      {
+        "release": "lv20",
+        "effect_type": "param_boost",
+        "param_type": "visual",
+        "param_value": 20,
+        "title": ""
+      },
+      {
+        "release": "lv40",
+        "effect_type": "card_enhance",
+        "title": ""
+      }
+    ],
+    "p_item": {
+      "name": "恋心のゆくえ",
+      "rarity": "ssr",
+      "memory": "memorizable",
+      "effect": {
+        "restriction": {
+          "key": "lesson_turn",
+          "param": "visual"
+        },
+        "trigger": {
+          "key": "turn_start_after"
+        },
+        "condition": {
+          "key": "keyword_state",
+          "keyword": "reserve"
+        },
+        "body": [
+          {
+            "key": "keyword_up_move_keyword",
+            "keyword": "vitality",
+            "keyword2": "aggressive",
+            "value": 3
+          }
+        ],
+        "limit": {
+          "key": "per_lesson",
+          "count": 3
+        }
+      }
+    },
+    "skill_card": null
+  },
+  {
+    "name": "ゆずれないもの",
+    "rarity": "sr",
+    "plan": "sense",
+    "type": "vocal",
+    "parameter_type": "vocal",
+    "source": "unit_limited",
+    "release_date": "2026/06/15",
+    "abilities": [
+      {
+        "name_key": "initial_stat",
+        "trigger_key": "vo_initial_stat",
+        "parameter_type": "vocal",
+        "values": {},
+        "is_initial_stat": true
+      },
+      {
+        "name_key": "sp_lesson_rate",
+        "trigger_key": "vo_sp_lesson_rate",
+        "parameter_type": "vocal",
+        "values": {},
+        "is_percentage": true,
+        "skip_calculation": true
+      },
+      {
+        "name_key": "support_rate",
+        "trigger_key": "support_rate",
+        "values": {},
+        "is_percentage": true,
+        "skip_calculation": true
+      },
+      {
+        "name_key": "sp_lesson_end",
+        "trigger_key": "vo_sp_lesson_end",
+        "parameter_type": "vocal",
+        "values": {}
+      },
+      {
+        "name_key": "activity_supply_gift_count",
+        "trigger_key": "activity_supply_gift_count",
+        "parameter_type": "vocal",
+        "values": {},
+        "max_count": 2
+      },
+      {
+        "name_key": "event_boost",
+        "trigger_key": "event_boost",
+        "values": {},
+        "is_percentage": true,
+        "is_event_boost": true
+      }
+    ],
+    "events": [
+      {
+        "release": "initial",
+        "effect_type": "p_item",
+        "title": "懐かしパーティー論争"
+      },
+      {
+        "release": "lv20",
+        "effect_type": "param_boost",
+        "param_type": "vocal",
+        "param_value": 15,
+        "title": ""
+      }
+    ],
+    "p_item": {
+      "name": "懐かしパーティー論争",
+      "rarity": "sr",
+      "memory": "non_memorizable",
+      "effect": {
+        "trigger": {
+          "key": "activity_supply_gift_selection"
+        },
+        "condition": {
+          "key": "param_gte",
+          "param": "vocal",
+          "threshold": 700
+        },
+        "body": [
+          {
+            "key": "param_up_select_copy",
+            "param": "vocal",
+            "value": 20
+          }
+        ],
+        "limit": {
+          "key": "per_produce",
+          "count": 1
+        }
+      },
+      "boost": {
+        "trigger_key": "activity_supply_gift",
+        "parameter_type": "vocal",
+        "value": 20,
+        "max_count": 1
+      }
+    },
+    "skill_card": null
   }
 ]

--- a/src/data/score/abilityValue.ts
+++ b/src/data/score/abilityValue.ts
@@ -89,6 +89,7 @@ const stageData = {
     [AbilityNameKeyType.SpLessonRateAll]: ['10.5%', '14%'],
     [AbilityNameKeyType.SpLessonRateAllHigh]: ['21%', '28%'],
     [AbilityNameKeyType.SsrCardAcquire]: ['5', '6'],
+    [AbilityNameKeyType.SpecialTraining]: ['18', '25'],
     [AbilityNameKeyType.ActivitySupplyGift]: ['12', '17'],
     [AbilityNameKeyType.ActivitySupplyGiftCount]: ['28', '38'],
     [AbilityNameKeyType.SupportRate]: ['66.1%', '74.6%', '83.1%', '91.5%', '100%'],
@@ -160,6 +161,7 @@ const stageData = {
     [AbilityNameKeyType.SpecialTraining]: ['9', '18'],
     [AbilityNameKeyType.SsrCardAcquire]: ['3', '5'],
     [AbilityNameKeyType.ActivitySupplyGift]: ['6', '11'],
+    [AbilityNameKeyType.ActivitySupplyGiftCount]: ['13', '26'],
     [AbilityNameKeyType.SupportRate]: ['59.2%', '69.4%', '79.6%', '89.8%', '100%'],
   },
   [RarityTierType.R]: {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -319,6 +319,7 @@
       "keyword_up": "{{keyword}}+{{value}}",
       "keyword_up_3": "{{keyword}}+{{value}}{{keyword2}}+{{count}}{{keyword3}}+{{turns}}",
       "keyword_up_move_ssr": "{{keyword}}+{{value}}ランダムな山札か捨札にあるスキルカード（SSR）を手札に移動",
+      "keyword_up_move_keyword": "{{keyword}}+{{value}}ランダムな山札か捨札の{{keyword2}}効果のスキルカードを手札に移動",
       "keyword_up_parameter": "{{keyword}}+{{value}}パラメータ+{{count}}",
       "keyword_up_hp_cost": "{{keyword}}+{{value}}体力消費{{count}}",
       "keyword_up_hp_recovery": "{{keyword}}+{{value}}体力回復{{count}}",

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -1299,6 +1299,8 @@ export const EffectTemplateKeyType = {
   MoveIdolHand: 'move_idol_hand',
   /** SSRスキルカード移動 */
   KeywordUpMoveSsr: 'keyword_up_move_ssr',
+  /** キーワード上昇+指定効果スキルカード移動 */
+  KeywordUpMoveKeyword: 'keyword_up_move_keyword',
 
   /** コスト減少 */
   CostReduce: 'cost_reduce',


### PR DESCRIPTION
## 概要
2026/06/15追加のユニットガチャ新カード2枚のデータを追加。

## 変更内容
- `どーなっちゃうの～？`（SSR / アノマリー / ビジュアル / ユニットガチャ）を追加
  - Pアイテム: `恋心のゆくえ`（メモリ可 / ビジュアルレッスン・ビジュアルターン限定）
  - 特別指導の abilityValue を 18 / 25 に対応
- `ゆずれないもの`（SR / センス / ボーカル / ユニットガチャ）を追加
  - Pアイテム: `懐かしパーティー論争`（メモリ不可 / 活動支給・差し入れ選択時）
  - 活動支給・差し入れ選択時の abilityValue を 13 / 26 に対応
- サポート追加フォーム用に回数付きアビリティの選択肢と既定回数をテストで固定

## 確認事項
- [x] npm run test:run
- [x] npm run build
