### PR TITLE
chore(data): 新カード2枚追加（おでん、通りま～すッ！ / ゆるるんあくび顔）

### DIFF
--- a/src/data/json/cards.json
+++ b/src/data/json/cards.json
@@ -22756,5 +22756,229 @@
       }
     },
     "skill_card": null
+  },
+  {
+    "name": "おでん、通りま～すッ！",
+    "rarity": "ssr",
+    "plan": "anomaly",
+    "type": "visual",
+    "parameter_type": "visual",
+    "source": "live_tour_limited",
+    "release_date": "2026/06/26",
+    "abilities": [
+      {
+        "name_key": "parameter_bonus",
+        "trigger_key": "vi_parameter_bonus",
+        "parameter_type": "visual",
+        "values": {},
+        "is_percentage": true,
+        "is_parameter_bonus": true
+      },
+      {
+        "name_key": "ssr_card_acquire",
+        "trigger_key": "ssr_card_acquire",
+        "parameter_type": "visual",
+        "values": {}
+      },
+      {
+        "name_key": "support_rate",
+        "trigger_key": "support_rate",
+        "values": {},
+        "is_percentage": true,
+        "skip_calculation": true
+      },
+      {
+        "name_key": "sp_lesson_end",
+        "trigger_key": "vi_sp_lesson_end",
+        "parameter_type": "visual",
+        "values": {}
+      },
+      {
+        "name_key": "outing_count",
+        "trigger_key": "outing_count",
+        "parameter_type": "visual",
+        "values": {},
+        "max_count": 2
+      },
+      {
+        "name_key": "event_boost",
+        "trigger_key": "event_boost",
+        "values": {},
+        "is_percentage": true,
+        "is_event_boost": true
+      }
+    ],
+    "events": [
+      {
+        "release": "initial",
+        "effect_type": "skill_card",
+        "title": ""
+      },
+      {
+        "release": "lv20",
+        "effect_type": "param_boost",
+        "param_type": "visual",
+        "param_value": 20,
+        "title": ""
+      },
+      {
+        "release": "lv40",
+        "effect_type": "card_enhance",
+        "title": ""
+      }
+    ],
+    "p_item": null,
+    "skill_card": {
+      "name": "あつあつはふはふ",
+      "rarity": "ssr",
+      "type": "active",
+      "lesson_limit": 1,
+      "no_duplicate": true,
+      "effects": [
+        {
+          "level": "base",
+          "cost_type": "vitality",
+          "cost_value": 6,
+          "effect": {
+            "groups": [
+              {
+                "action": {
+                  "key": "keyword_up",
+                  "value": 1,
+                  "keyword": "full_power_value"
+                }
+              },
+              {
+                "condition": {
+                  "key": "keyword_state",
+                  "keyword": "full_power"
+                },
+                "temporal": {
+                  "key": "up_to_n_times",
+                  "count": 4
+                },
+                "trigger": {
+                  "key": "turn_end"
+                },
+                "action": {
+                  "key": "param_up_cumulative_keyword_pct_boost",
+                  "value": 3,
+                  "keyword": "full_power_value",
+                  "pct": 150
+                },
+                "temporal_first": true
+              }
+            ]
+          }
+        }
+      ],
+      "custom_cap": 1,
+      "custom_slot": []
+    }
+  },
+  {
+    "name": "ゆるるんあくび顔",
+    "rarity": "sr",
+    "plan": "anomaly",
+    "type": "visual",
+    "parameter_type": "visual",
+    "source": "live_tour_limited",
+    "release_date": "2026/06/26",
+    "abilities": [
+      {
+        "name_key": "parameter_bonus",
+        "trigger_key": "vi_parameter_bonus",
+        "parameter_type": "visual",
+        "values": {},
+        "is_percentage": true,
+        "is_parameter_bonus": true
+      },
+      {
+        "name_key": "activity_supply_gift_count",
+        "trigger_key": "activity_supply_gift_count",
+        "parameter_type": "visual",
+        "values": {},
+        "max_count": 2
+      },
+      {
+        "name_key": "support_rate",
+        "trigger_key": "support_rate",
+        "values": {},
+        "is_percentage": true,
+        "skip_calculation": true
+      },
+      {
+        "name_key": "sp_lesson_end",
+        "trigger_key": "vi_sp_lesson_end",
+        "parameter_type": "visual",
+        "values": {}
+      },
+      {
+        "name_key": "reserve_card_acquire",
+        "trigger_key": "reserve_card_acquire",
+        "parameter_type": "visual",
+        "values": {}
+      },
+      {
+        "name_key": "event_boost",
+        "trigger_key": "event_boost",
+        "values": {},
+        "is_percentage": true,
+        "is_event_boost": true
+      }
+    ],
+    "events": [
+      {
+        "release": "initial",
+        "effect_type": "p_item",
+        "title": ""
+      },
+      {
+        "release": "lv20",
+        "effect_type": "param_boost",
+        "param_type": "visual",
+        "param_value": 15,
+        "title": ""
+      }
+    ],
+    "p_item": {
+      "name": "居眠り注意！",
+      "rarity": "sr",
+      "memory": "non_memorizable",
+      "effect": {
+        "trigger": {
+          "key": "consult_selection"
+        },
+        "condition": {
+          "key": "param_gte",
+          "param": "visual",
+          "threshold": 400
+        },
+        "body": [
+          {
+            "key": "param_up",
+            "param": "visual",
+            "value": 10
+          },
+          {
+            "key": "random_skill_card_r_acquire"
+          }
+        ],
+        "limit": {
+          "key": "per_produce",
+          "count": 2
+        }
+      },
+      "boost": {
+        "trigger_key": "consult",
+        "parameter_type": "visual",
+        "value": 10,
+        "max_count": 2
+      },
+      "provided_action_ids": {
+        "skill_acquire": 1
+      }
+    },
+    "skill_card": null
   }
 ]

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -300,6 +300,7 @@
       "pp_gain": "Pポイント+{{value}}",
       "parameter_up": "パラメータ+{{value}}",
       "random_enhance": "ランダムなスキルカードを強化",
+      "random_skill_card_r_acquire": "ランダムなスキルカード（R）を獲得",
       "random_pdrink_sr": "ランダムなPドリンク（SR以上）を獲得",
       "random_pdrink": "ランダムなPドリンクを獲得",
       "random_pdrink_count": "ランダムなPドリンクを{{count}}つ獲得",
@@ -389,6 +390,7 @@
         "delay": "{{turns}}ターン後、",
         "ongoing": "以降の{{turns}}ターンの間、",
         "every_n_card_use": "以降、スキルカードを{{count}}回使用するごとに、",
+        "up_to_n_times": "以降{{count}}回まで、",
         "up_to_n_card_use": "以降{{count}}回まで、{{skill_type}}スキルカード使用時、"
       },
       "trigger": {
@@ -399,6 +401,7 @@
       "action": {
         "param_up": "パラメータ+{{value}}",
         "param_up_multi": "パラメータ+{{value}}（{{count}}回）",
+        "param_up_cumulative_keyword_pct_boost": "パラメータ+{{value}}（累積{{keyword}}の{{pct}}%分、パラメータ上昇量増加）",
         "param_up_keyword_multiply": "パラメータ+{{value}}({{keyword}}効果を{{rate}}倍適用)",
         "keyword_pct_param_up": "{{keyword}}の{{pct}}%分パラメータ上昇",
         "param_boost": "パラメータ上昇量増加{{pct}}％（{{turns}}ターン）",

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -1246,6 +1246,8 @@ export const EffectTemplateKeyType = {
   ParamUpKeywordMultiply: 'param_up_keyword_multiply',
   /** パラメータ上昇（複数） */
   ParamUpMulti: 'param_up_multi',
+  /** パラメータ上昇+累積キーワード依存の上昇量増加 */
+  ParamUpCumulativeKeywordPctBoost: 'param_up_cumulative_keyword_pct_boost',
 
   /** スキルカード強化 */
   CardEnhance: 'card_enhance',
@@ -1271,6 +1273,8 @@ export const EffectTemplateKeyType = {
   RandomEnhanceHp: 'random_enhance_hp',
   /** ランダム強化+Pポイント */
   RandomEnhancePp: 'random_enhance_pp',
+  /** ランダムRスキルカード獲得 */
+  RandomSkillCardRAcquire: 'random_skill_card_r_acquire',
   /** 手札全入れ替え */
   ReplaceAllHand: 'replace_all_hand',
   /** スキルカード選択強化 */
@@ -1445,6 +1449,8 @@ export const EffectTemplateKeyType = {
   Delta: 'delta',
   /** N回カード使用ごと */
   EveryNCardUse: 'every_n_card_use',
+  /** N回まで */
+  UpToNTimes: 'up_to_n_times',
   /** N回まで使用 */
   UpToNCardUse: 'up_to_n_card_use',
   /** 次のターン */


### PR DESCRIPTION
## 概要
ライブツアー限定の新カードデータを追加。

## 変更内容
- `おでん、通りま～すッ！`（SSR）
- `ゆるるんあくび顔`（SR）
- 新しいスキルカード/Pアイテム効果キーの表示名を追加

## 確認事項
- [x] 動作確認済み
- [x] `npm run build`
- [x] `npm run test:run`
- [x] `npm run test:run -- src/__tests__/data/cards.test.ts src/__tests__/data/masterData.test.ts`
