### PR TITLE
perf: 遅延UIチャンクを起動時に先読み

### DIFF
--- a/src/__tests__/utils/lazyPreload.test.ts
+++ b/src/__tests__/utils/lazyPreload.test.ts
@@ -1,0 +1,48 @@
+/**
+ * 遅延モジュールの共有ローダーと先読みを検証する。
+ */
+import { render, screen } from '@testing-library/react'
+import { Suspense, createElement } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import * as lazyPreload from '../../utils/lazyPreload'
+import { createPreloadedComponent } from '../../utils/preloadedComponent'
+
+describe('lazyPreload', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('同じ遅延モジュールのPromiseを共有してimportを1回にする', async () => {
+    const importer = vi.fn(() => Promise.resolve({ default: 'loaded' }))
+    const load = lazyPreload.createLazyModuleLoader(importer)
+
+    expect(load.getResolved()).toBeUndefined()
+    const first = load()
+    const second = load()
+
+    expect(first).toBe(second)
+    await first
+    expect(importer).toHaveBeenCalledTimes(1)
+    expect(load.getResolved()).toEqual({ default: 'loaded' })
+  })
+
+  it('先読み完了済みなら初回表示でSuspenseのフォールバックを経由しない', async () => {
+    const importer = vi.fn(() => Promise.resolve({ default: () => createElement('span', null, 'ready') }))
+    const load = lazyPreload.createLazyModuleLoader(importer)
+    const PreloadedComponent = createPreloadedComponent(load)
+
+    await load()
+    const view = render(
+      createElement(
+        Suspense,
+        { fallback: createElement('span', null, 'loading') },
+        createElement(PreloadedComponent),
+      ),
+    )
+
+    expect(screen.getByText('ready')).toBeTruthy()
+    expect(screen.queryByText('loading')).toBeNull()
+    view.unmount()
+  })
+})

--- a/src/__tests__/utils/lazyPreload.test.ts
+++ b/src/__tests__/utils/lazyPreload.test.ts
@@ -34,11 +34,7 @@ describe('lazyPreload', () => {
 
     await load()
     const view = render(
-      createElement(
-        Suspense,
-        { fallback: createElement('span', null, 'loading') },
-        createElement(PreloadedComponent),
-      ),
+      createElement(Suspense, { fallback: createElement('span', null, 'loading') }, createElement(PreloadedComponent)),
     )
 
     expect(screen.getByText('ready')).toBeTruthy()

--- a/src/components/app/AppModals.tsx
+++ b/src/components/app/AppModals.tsx
@@ -3,17 +3,21 @@
  *
  * 各モーダルの開閉条件とデータ受け渡しだけを担当し、通常ページや固定パネルのレイアウトから分離する。
  */
-import { Suspense, lazy } from 'react'
+import { Suspense } from 'react'
+import * as constant from '../../constant'
 import type { AppOptionsState } from '../../hooks/useAppOptions'
 import type { AppState } from '../../hooks/useAppState'
 import type { CardInteractions } from '../../hooks/useCardInteractions'
 import { createEmptyResult } from '../../utils/calculator/calculateCard'
+import * as lazyModules from '../../utils/lazyModules'
+import { createPreloadedComponent } from '../../utils/preloadedComponent'
+import { ModalLoadingFallback } from '../ui/ModalLoadingFallback'
 
-const CardDetailModal = lazy(() => import('../cardDetailModal/CardDetailModal'))
-const ScoreDetailModal = lazy(() => import('../scoreDetailModal/ScoreDetailModal'))
-const FilterSortModal = lazy(() => import('../filterBar/FilterSortModal'))
-const UserCardFormModal = lazy(() => import('../userCardForm/UserCardFormModal'))
-const OptionsModal = lazy(() => import('../optionsModal/OptionsModal'))
+const FilterSortModal = createPreloadedComponent(lazyModules.loadFilterSortModal)
+const CardDetailModal = createPreloadedComponent(lazyModules.loadCardDetailModal)
+const ScoreDetailModal = createPreloadedComponent(lazyModules.loadScoreDetailModal)
+const UserCardFormModal = createPreloadedComponent(lazyModules.loadUserCardFormModal)
+const OptionsModal = createPreloadedComponent(lazyModules.loadOptionsModal)
 
 // モーダルの遅延読込・開閉条件・共通の配置計算を一箇所に集約し、Appの組み立てを簡潔にする
 interface AppModalsProps {
@@ -41,7 +45,9 @@ export function AppModals({ state, cardInteractions, options, panelRightOffset }
     <>
       {/* フィルター・ソートモーダル */}
       {state.ui.filterSortOpen && (
-        <Suspense fallback={null}>
+        <Suspense
+          fallback={<ModalLoadingFallback panelClassName={constant.MODAL_PANEL_FILTER} className={panelRightOffset} />}
+        >
           <FilterSortModal
             onClose={() => state.ui.setFilterSortOpen(false)}
             filters={state.filters}
@@ -54,7 +60,7 @@ export function AppModals({ state, cardInteractions, options, panelRightOffset }
 
       {/* サポートカード詳細 */}
       {selectedCard && (
-        <Suspense fallback={null}>
+        <Suspense fallback={<ModalLoadingFallback />}>
           <CardDetailModal
             card={selectedCard}
             uncap={state.scores.getCardUncap(selectedCard.name)}
@@ -70,7 +76,7 @@ export function AppModals({ state, cardInteractions, options, panelRightOffset }
 
       {/* 点数内訳・回数調整 */}
       {scoreBreakdown && (
-        <Suspense fallback={null}>
+        <Suspense fallback={<ModalLoadingFallback panelClassName={constant.MODAL_PANEL_SCORE} />}>
           <ScoreDetailModal
             card={scoreBreakdown.card}
             result={state.scores.cardResults.get(scoreBreakdown.card.name) ?? createEmptyResult(scoreBreakdown.card)}
@@ -95,7 +101,7 @@ export function AppModals({ state, cardInteractions, options, panelRightOffset }
 
       {/* ユーザー追加カードの編集・新規登録フォーム */}
       {state.ui.userCardFormOpen && (
-        <Suspense fallback={null}>
+        <Suspense fallback={<ModalLoadingFallback panelClassName={constant.MODAL_PANEL_USER_CARD} />}>
           <UserCardFormModal
             onClose={() => {
               state.ui.setUserCardFormOpen(false)
@@ -122,7 +128,7 @@ export function AppModals({ state, cardInteractions, options, panelRightOffset }
 
       {/* 表示設定・最適編成設定のオプションモーダル */}
       {options.isOpen && (
-        <Suspense fallback={null}>
+        <Suspense fallback={<ModalLoadingFallback panelClassName={constant.MODAL_PANEL_OPTIONS} />}>
           <OptionsModal
             onClose={options.close}
             preferences={options.preferences}

--- a/src/components/app/AppSettingsPanels.tsx
+++ b/src/components/app/AppSettingsPanels.tsx
@@ -4,14 +4,17 @@
  * パネル間の切り替えと、一覧からサポートを選ぶための接続だけを
  * ルートコンポーネントから受け取る
  */
-import { Suspense, lazy, useCallback } from 'react'
+import { Suspense, useCallback } from 'react'
 import type { AppState } from '../../hooks/useAppState'
 import type { PanelNavigationActions } from '../../hooks/usePanelNavigation'
 import type { UnitCardSelectionBridge } from '../../hooks/useUnitCardSelectionBridge'
+import * as lazyModules from '../../utils/lazyModules'
+import { createPreloadedComponent } from '../../utils/preloadedComponent'
 import { ErrorBoundary } from '../ui/ErrorBoundary'
+import { PanelLoadingFallback } from '../ui/PanelLoadingFallback'
 
-const ScoreSettingsPanel = lazy(() => import('../scoreSettingsPanel/ScoreSettingsPanel'))
-const UnitSimulatorPanel = lazy(() => import('../unitSimulator/UnitSimulatorPanel'))
+const ScoreSettingsPanel = createPreloadedComponent(lazyModules.loadScoreSettingsPanel)
+const UnitSimulatorPanel = createPreloadedComponent(lazyModules.loadUnitSimulatorPanel)
 
 interface AppSettingsPanelsProps {
   /** アプリ全体の統合状態 */
@@ -47,7 +50,11 @@ export function AppSettingsPanels({ state, navigation, selection, reserveMobileN
       {/* 点数設定パネル（表示条件に応じた遅延読込） */}
       {(state.ui.scoreSettingsOpen || state.ui.settingsPinned) && (
         <ErrorBoundary onCancel={closeScoreSettings}>
-          <Suspense fallback={null}>
+          <Suspense
+            fallback={
+              <PanelLoadingFallback pinned={state.ui.settingsPinned} reserveMobileNavSpace={reserveMobileNavSpace} />
+            }
+          >
             {/* 点数設定パネル */}
             <ScoreSettingsPanel
               isOpen={state.ui.scoreSettingsOpen}
@@ -65,7 +72,15 @@ export function AppSettingsPanels({ state, navigation, selection, reserveMobileN
       {/* 最適編成パネル（手動選択中もマウント維持） */}
       {(state.ui.simulatorOpen || state.ui.simulatorPinned || state.ui.unitCardSelectMode) && (
         <ErrorBoundary>
-          <Suspense fallback={null}>
+          <Suspense
+            fallback={
+              <PanelLoadingFallback
+                pinned={state.ui.simulatorPinned}
+                secondPanel={state.ui.bothPanelsPinned}
+                reserveMobileNavSpace={reserveMobileNavSpace}
+              />
+            }
+          >
             {/* 最適編成パネル */}
             <UnitSimulatorPanel
               isOpen={state.ui.simulatorOpen}

--- a/src/components/filterBar/FilterSortModal.tsx
+++ b/src/components/filterBar/FilterSortModal.tsx
@@ -4,7 +4,6 @@
  * ソートとフィルタの操作をタブ切り替えで提供するモーダル。
  * 縦幅が足りない画面でもスクロール可能なモーダル内で操作できるようにする。
  */
-import { memo } from 'react'
 import * as constant from '../../constant'
 import type { CardFiltersReturn } from '../../hooks'
 import * as enums from '../../types/enums'
@@ -35,7 +34,7 @@ interface FilterSortModalProps {
  * @param props - フィルター状態、選択中タブ、モーダル操作
  * @returns PCとスマホに対応したフィルタ・ソートモーダル
  */
-export default memo(function FilterSortModal({
+export default function FilterSortModal({
   onClose,
   filters,
   panelRightOffset,
@@ -81,4 +80,4 @@ export default memo(function FilterSortModal({
       </div>
     </ModalOverlay>
   )
-})
+}

--- a/src/components/header/AppHeader.tsx
+++ b/src/components/header/AppHeader.tsx
@@ -5,16 +5,20 @@
  * アプリタイトル、凸数設定/スコア設定/最適編成ボタン、
  * データ管理パネル、モバイルメニューを含む。
  */
-import { Suspense, lazy, useRef, useState } from 'react'
+import { Suspense, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import * as constant from '../../constant'
 import { useCardUIContext } from '../../contexts/CardContext'
 import { useHeaderHeightCssVariable } from '../../hooks/useHeaderHeightCssVariable'
+import * as lazyModules from '../../utils/lazyModules'
+import { createPreloadedComponent } from '../../utils/preloadedComponent'
+import { ModalLoadingFallback } from '../ui/ModalLoadingFallback'
 import { DesktopHeaderNavigation } from './DesktopHeaderNavigation'
 import { MobileMenu } from './MobileMenu'
 
-const HelpModal = lazy(() => import('../helpModal/HelpModal'))
-const AboutModal = lazy(() => import('../aboutModal/AboutModal'))
-const DataManagementModal = lazy(() => import('./dataManagement/DataManagementModal'))
+const HelpModal = createPreloadedComponent(lazyModules.loadHelpModal)
+const AboutModal = createPreloadedComponent(lazyModules.loadAboutModal)
+const DataManagementModal = createPreloadedComponent(lazyModules.loadDataManagementModal)
 
 /** AppHeader コンポーネントに渡すプロパティ */
 interface AppHeaderProps {
@@ -152,19 +156,19 @@ export default function AppHeader({
           </div>
         </div>
         {helpOpen && (
-          <Suspense fallback={null}>
+          <Suspense fallback={<ModalLoadingFallback />}>
             {/* ヘルプモーダル */}
             <HelpModal onClose={() => setHelpOpen(false)} />
           </Suspense>
         )}
         {aboutOpen && (
-          <Suspense fallback={null}>
+          <Suspense fallback={<ModalLoadingFallback />}>
             {/* Aboutモーダル */}
             <AboutModal onClose={() => setAboutOpen(false)} />
           </Suspense>
         )}
         {dataManagementOpen && (
-          <Suspense fallback={null}>
+          <Suspense fallback={<ModalLoadingFallback panelClassName={constant.MODAL_PANEL_DETAIL} />}>
             {/* データ管理モーダル */}
             <DataManagementModal onClose={() => setDataManagementOpen(false)} />
           </Suspense>

--- a/src/components/header/DeferredMoreMenuItems.tsx
+++ b/src/components/header/DeferredMoreMenuItems.tsx
@@ -1,16 +1,14 @@
-import { Suspense, lazy } from 'react'
+import { Suspense } from 'react'
+import * as lazyModules from '../../utils/lazyModules'
+import { createPreloadedComponent } from '../../utils/preloadedComponent'
 import type { MoreMenuItemsProps } from './MoreMenuItems'
 
-const MoreMenuItems = lazy(() =>
-  import('./MoreMenuItems').then(({ MoreMenuItems: Component }) => ({ default: Component })),
-)
+const MoreMenuItems = createPreloadedComponent(lazyModules.loadMoreMenuItems)
+
 /**
- * 初回表示では使わない「その他」の項目を、メニューを開いた時だけ読み込む。
- * 親メニューのレイアウトは各ナビゲーション側に残し、共通項目だけを
- * 遅延境界に入れる
+ * その他メニューの遅延コンポーネントを共通のSuspense境界で表示する。
  */
 export function DeferredMoreMenuItems(props: MoreMenuItemsProps) {
-  // 「その他」は初回表示に必須ではないため、操作時のチャンクへ分ける
   return (
     <Suspense fallback={null}>
       {/* 共通のその他メニュー項目 */}

--- a/src/components/ui/ModalLoadingFallback.tsx
+++ b/src/components/ui/ModalLoadingFallback.tsx
@@ -1,0 +1,44 @@
+/** モーダルの遅延チャンク取得中に表示領域を保つfallback */
+import { createPortal } from 'react-dom'
+import * as constant from '../../constant'
+
+interface ModalLoadingFallbackProps {
+  /** モーダル本体のサイズ・配置クラス */
+  panelClassName?: string
+  /** モーダル外側へ追加する配置クラス */
+  className?: string
+}
+
+function LoadingBars() {
+  return (
+    <div className="space-y-4 p-5" aria-hidden="true">
+      <div className="h-5 w-2/5 animate-pulse rounded bg-slate-300" />
+      <div className="h-24 animate-pulse rounded-xl bg-slate-100 ring-1 ring-slate-200" />
+      <div className="grid grid-cols-2 gap-3">
+        <div className="h-10 animate-pulse rounded-lg bg-slate-100 ring-1 ring-slate-200" />
+        <div className="h-10 animate-pulse rounded-lg bg-slate-100 ring-1 ring-slate-200" />
+      </div>
+      <div className="h-3 w-4/5 animate-pulse rounded bg-slate-200" />
+      <div className="h-3 w-3/5 animate-pulse rounded bg-slate-100" />
+    </div>
+  )
+}
+
+/** モーダルの遅延読込中に、実際のモーダルと同じ外枠を表示する */
+export function ModalLoadingFallback({
+  panelClassName = constant.MODAL_PANEL_DETAIL,
+  className = '',
+}: ModalLoadingFallbackProps) {
+  return createPortal(
+    <div
+      className={`fixed inset-0 z-[80] flex items-center justify-center px-4 pb-[max(1rem,env(safe-area-inset-bottom))] pt-[max(1rem,env(safe-area-inset-top))] ${className}`}
+      aria-busy="true"
+    >
+      <div className={constant.MODAL_BACKDROP} />
+      <div className={panelClassName}>
+        <LoadingBars />
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/components/ui/PanelLoadingFallback.tsx
+++ b/src/components/ui/PanelLoadingFallback.tsx
@@ -1,0 +1,52 @@
+/** サイドパネルの遅延チャンク取得中に表示領域を保つfallback */
+import * as constant from '../../constant'
+
+interface PanelLoadingFallbackProps {
+  /** パネルを固定表示するか */
+  pinned: boolean
+  /** 2枚目の固定パネルとして表示するか */
+  secondPanel?: boolean
+  /** スマホ下部ナビ分の余白を確保するか */
+  reserveMobileNavSpace?: boolean
+}
+
+/** サイドパネルの遅延読込中に、固定・オーバーレイの表示領域を確保する */
+export function PanelLoadingFallback({
+  pinned,
+  secondPanel = false,
+  reserveMobileNavSpace = true,
+}: PanelLoadingFallbackProps) {
+  const content = (
+    <div className="h-full" aria-busy="true">
+      <div className="h-[var(--app-header-height,3.5rem)] border-b border-slate-200 bg-white" />
+      <div className="space-y-4 p-5" aria-hidden="true">
+        <div className="h-5 w-2/5 animate-pulse rounded bg-slate-300" />
+        <div className="h-28 animate-pulse rounded-xl bg-slate-100 ring-1 ring-slate-200" />
+        <div className="h-10 animate-pulse rounded-lg bg-slate-100 ring-1 ring-slate-200" />
+        <div className="h-10 animate-pulse rounded-lg bg-slate-100 ring-1 ring-slate-200" />
+        <div className="h-3 w-4/5 animate-pulse rounded bg-slate-200" />
+      </div>
+    </div>
+  )
+
+  if (pinned) {
+    return (
+      <div
+        className={`${secondPanel ? constant.PANEL_PINNED_SECOND : constant.PANEL_PINNED} ${constant.PANEL_SCROLL_STABLE} overscroll-y-contain`}
+      >
+        {content}
+      </div>
+    )
+  }
+
+  return (
+    <div className="fixed inset-0 z-30 flex overscroll-none justify-end pt-[env(safe-area-inset-top)] md:z-50 md:pb-[env(safe-area-inset-bottom)]">
+      <div className={constant.MODAL_BACKDROP} />
+      <div
+        className={`${constant.PANEL_OVERLAY} ${constant.PANEL_SCROLL_STABLE} overscroll-y-contain md:pb-0 ${reserveMobileNavSpace ? 'pb-[calc(4.5rem+env(safe-area-inset-bottom))]' : 'pb-[env(safe-area-inset-bottom)]'}`}
+      >
+        {content}
+      </div>
+    </div>
+  )
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,8 @@ import App from './App.tsx'
 import { ErrorBoundary } from './components/ui/ErrorBoundary.tsx'
 import './i18n'
 import './index.css'
+import * as lazyModules from './utils/lazyModules'
+import { preloadAllLazyModules } from './utils/lazyPreload'
 
 registerSW({
   immediate: true,
@@ -13,6 +15,10 @@ registerSW({
     console.error('Service Worker registration failed:', error)
   },
 })
+
+// メインエントリ実行直後から遅延UIチャンクの取得・評価を開始する。
+// dynamic importの別チャンク構成は維持し、メインJSへは結合しない。
+void preloadAllLazyModules(lazyModules.INITIAL_PRELOAD_MODULES)
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/utils/lazyModules.ts
+++ b/src/utils/lazyModules.ts
@@ -8,10 +8,14 @@ export const loadFilterSortModal = createLazyModuleLoader(() => import('../compo
 export const loadCardDetailModal = createLazyModuleLoader(() => import('../components/cardDetailModal/CardDetailModal'))
 
 /** 点数詳細モーダルの共有ローダー */
-export const loadScoreDetailModal = createLazyModuleLoader(() => import('../components/scoreDetailModal/ScoreDetailModal'))
+export const loadScoreDetailModal = createLazyModuleLoader(
+  () => import('../components/scoreDetailModal/ScoreDetailModal'),
+)
 
 /** ユーザー追加カードフォームの共有ローダー */
-export const loadUserCardFormModal = createLazyModuleLoader(() => import('../components/userCardForm/UserCardFormModal'))
+export const loadUserCardFormModal = createLazyModuleLoader(
+  () => import('../components/userCardForm/UserCardFormModal'),
+)
 
 /** オプションモーダルの共有ローダー */
 export const loadOptionsModal = createLazyModuleLoader(() => import('../components/optionsModal/OptionsModal'))
@@ -28,8 +32,8 @@ export const loadDataManagementModal = createLazyModuleLoader(
 )
 
 /** その他メニュー項目の共有ローダー */
-export const loadMoreMenuItems = createLazyModuleLoader(
-  () => import('../components/header/MoreMenuItems').then(({ MoreMenuItems }) => ({ default: MoreMenuItems })),
+export const loadMoreMenuItems = createLazyModuleLoader(() =>
+  import('../components/header/MoreMenuItems').then(({ MoreMenuItems }) => ({ default: MoreMenuItems })),
 )
 
 /** 点数設定パネルの共有ローダー */

--- a/src/utils/lazyModules.ts
+++ b/src/utils/lazyModules.ts
@@ -1,0 +1,58 @@
+/** 遅延表示する画面のimportを一か所へ集約し、表示処理と先読みで共有する */
+import { createLazyModuleLoader } from './lazyPreload'
+
+/** フィルター・ソートモーダルの共有ローダー */
+export const loadFilterSortModal = createLazyModuleLoader(() => import('../components/filterBar/FilterSortModal'))
+
+/** カード詳細モーダルの共有ローダー */
+export const loadCardDetailModal = createLazyModuleLoader(() => import('../components/cardDetailModal/CardDetailModal'))
+
+/** 点数詳細モーダルの共有ローダー */
+export const loadScoreDetailModal = createLazyModuleLoader(() => import('../components/scoreDetailModal/ScoreDetailModal'))
+
+/** ユーザー追加カードフォームの共有ローダー */
+export const loadUserCardFormModal = createLazyModuleLoader(() => import('../components/userCardForm/UserCardFormModal'))
+
+/** オプションモーダルの共有ローダー */
+export const loadOptionsModal = createLazyModuleLoader(() => import('../components/optionsModal/OptionsModal'))
+
+/** ヘルプモーダルの共有ローダー */
+export const loadHelpModal = createLazyModuleLoader(() => import('../components/helpModal/HelpModal'))
+
+/** Aboutモーダルの共有ローダー */
+export const loadAboutModal = createLazyModuleLoader(() => import('../components/aboutModal/AboutModal'))
+
+/** データ管理モーダルの共有ローダー */
+export const loadDataManagementModal = createLazyModuleLoader(
+  () => import('../components/header/dataManagement/DataManagementModal'),
+)
+
+/** その他メニュー項目の共有ローダー */
+export const loadMoreMenuItems = createLazyModuleLoader(
+  () => import('../components/header/MoreMenuItems').then(({ MoreMenuItems }) => ({ default: MoreMenuItems })),
+)
+
+/** 点数設定パネルの共有ローダー */
+export const loadScoreSettingsPanel = createLazyModuleLoader(
+  () => import('../components/scoreSettingsPanel/ScoreSettingsPanel'),
+)
+
+/** 最適編成パネルの共有ローダー */
+export const loadUnitSimulatorPanel = createLazyModuleLoader(
+  () => import('../components/unitSimulator/UnitSimulatorPanel'),
+)
+
+/** アプリ起動直後に取得・評価を開始する遅延画面 */
+export const INITIAL_PRELOAD_MODULES = [
+  loadFilterSortModal,
+  loadCardDetailModal,
+  loadScoreDetailModal,
+  loadUnitSimulatorPanel,
+  loadScoreSettingsPanel,
+  loadUserCardFormModal,
+  loadOptionsModal,
+  loadMoreMenuItems,
+  loadHelpModal,
+  loadAboutModal,
+  loadDataManagementModal,
+] as const

--- a/src/utils/lazyPreload.ts
+++ b/src/utils/lazyPreload.ts
@@ -1,0 +1,44 @@
+/**
+ * 遅延importの共有ローダーと起動時先読み。
+ *
+ * 実際に表示する処理と先読みで同じPromiseを使い、同一チャンクの二重取得を避ける。
+ */
+
+/** 先読み完了状態を表示側から参照できる遅延モジュールローダー */
+export type LazyModuleLoader<T> = (() => Promise<T>) & {
+  getResolved: () => T | undefined
+}
+
+/** 遅延importのPromiseを共有するローダーを作成する */
+export function createLazyModuleLoader<T>(importer: () => Promise<T>): LazyModuleLoader<T> {
+  let promise: Promise<T> | undefined
+  let resolved: T | undefined
+  const load = (() => {
+    if (!promise) {
+      // 先読み失敗時はPromiseを破棄し、ユーザー操作で再試行できるようにする
+      promise = importer()
+        .then((module) => {
+          resolved = module
+          return module
+        })
+        .catch((error: unknown) => {
+          promise = undefined
+          resolved = undefined
+          throw error
+        })
+    }
+    return promise
+  }) as LazyModuleLoader<T>
+  load.getResolved = () => resolved
+  return load
+}
+
+/**
+ * 登録済みの遅延モジュールを起動直後にまとめて取得・評価する。
+ *
+ * Promiseを待たずに呼び出せるため、Reactのroot作成と並行して進む。
+ * dynamic importのチャンク構成は維持し、メインJSへは結合しない。
+ */
+export function preloadAllLazyModules(loaders: readonly (() => Promise<unknown>)[]): Promise<void> {
+  return Promise.all(loaders.map((loader) => loader().catch(() => undefined))).then(() => undefined)
+}

--- a/src/utils/preloadedComponent.tsx
+++ b/src/utils/preloadedComponent.tsx
@@ -1,0 +1,23 @@
+/**
+ * 先読み済みのdynamic importを、初回表示時だけ同期的に利用するための補助。
+ *
+ * モジュール自体はdynamic importの別チャンクに残る。先読みが完了していれば
+ * React.lazyの内部状態を経由せずに表示し、未完了ならPromiseをSuspenseへ渡す。
+ */
+import { type ComponentType, createElement } from 'react'
+import type { LazyModuleLoader } from './lazyPreload'
+
+interface DefaultComponentModule<P extends object> {
+  default: ComponentType<P>
+}
+
+/** 先読み完了時の同期表示と、未完了時のSuspenseを共通化する */
+export function createPreloadedComponent<P extends object>(
+  loader: LazyModuleLoader<DefaultComponentModule<P>>,
+): ComponentType<P> {
+  return function PreloadedComponent(props: P) {
+    const module = loader.getResolved()
+    if (!module) throw loader()
+    return createElement(module.default, props)
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,33 +31,6 @@ function gtagPlugin(gaId: string): Plugin {
   }
 }
 
-// 遅延チャンクをページ読み込み完了後に <link rel="prefetch"> で注入するプラグイン
-function prefetchLazyChunks(basePath: string): Plugin {
-  return {
-    name: 'prefetch-lazy-chunks',
-    enforce: 'post',
-    transformIndexHtml: {
-      order: 'post',
-      handler(_html, ctx) {
-        if (!ctx.bundle) return []
-        const urls = Object.entries(ctx.bundle)
-          .filter(([, chunk]) => chunk.type === 'chunk' && !chunk.isEntry && chunk.isDynamicEntry)
-          .map(([fileName]) => `${basePath}${fileName}`)
-        if (urls.length === 0) return []
-        const script = [
-          'window.addEventListener("load",function(){',
-          ...urls.map(
-            (u, i) =>
-              `var l${i}=document.createElement("link");l${i}.rel="prefetch";l${i}.href="${u}";document.head.appendChild(l${i});`,
-          ),
-          '});',
-        ].join('')
-        return [{ tag: 'script', attrs: { type: 'text/javascript' }, children: script, injectTo: 'body' as const }]
-      },
-    },
-  }
-}
-
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd())
@@ -68,7 +41,6 @@ export default defineConfig(({ mode }) => {
     plugins: [
       react(),
       gtagPlugin(env.VITE_GA_ID || ''),
-      prefetchLazyChunks(basePath),
       VitePWA({
         manifest: false,
         scope: basePath,


### PR DESCRIPTION
## 概要
- 遅延UIのdynamic importローダーを共有し、起動直後から各チャンクの取得・評価を開始
- 先読み済みモジュールはSuspenseのフォールバックを経由せず表示
- モーダル・設定パネルのフォールバックを分離
- 旧prefetchプラグインを削除し、初回先読み処理へ統一
- 効果のないFilterSortModalのmemoを削除

## 確認
- `npm run lint`
- `npm run build`
- `npm run test:run -- --reporter=dot`（41ファイル・1,775テスト成功）
- `git diff --check`